### PR TITLE
[MM-15960] Fixed 'no feedback on failed zoom icon click'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/hashicorp/go-hclog v0.0.0-20180910232447-e45cbeb79f04 // indirect
 	github.com/hashicorp/go-plugin v0.0.0-20180814222501-a4620f9913d1 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
-	github.com/mattermost/mattermost-plugin-zoom v1.0.3
 	github.com/mattermost/mattermost-server v5.6.1+incompatible
 	github.com/mattermost/viper v1.0.4 // indirect
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mattermost/mattermost-plugin-zoom/server
+module github.com/mattermost/mattermost-plugin-zoom
 
 go 1.12
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
 
-	zd "github.com/mattermost/mattermost-plugin-zoom/server/zoom"
+	zd "github.com/mattermost/mattermost-plugin-zoom/server/server/zoom"
 )
 
 const (

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
 
-	zd "github.com/mattermost/mattermost-plugin-zoom/server/server/zoom"
+	"github.com/mattermost/mattermost-plugin-zoom/server/zoom"
 )
 
 const (
@@ -25,7 +25,7 @@ const (
 type Plugin struct {
 	plugin.MattermostPlugin
 
-	zoomClient *zd.Client
+	zoomClient *zoom.Client
 
 	// configurationLock synchronizes access to the configuration.
 	configurationLock sync.RWMutex
@@ -41,7 +41,7 @@ func (p *Plugin) OnActivate() error {
 		return err
 	}
 
-	p.zoomClient = zd.NewClient(config.ZoomAPIURL, config.APIKey, config.APISecret)
+	p.zoomClient = zoom.NewClient(config.ZoomAPIURL, config.APIKey, config.APISecret)
 
 	return nil
 }
@@ -76,7 +76,7 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var webhook zd.Webhook
+	var webhook zoom.Webhook
 
 	decoder := schema.NewDecoder()
 
@@ -91,8 +91,8 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	// TODO: handle recording webhook
 }
 
-func (p *Plugin) handleStandardWebhook(w http.ResponseWriter, r *http.Request, webhook *zd.Webhook) {
-	if webhook.Status != zd.WEBHOOK_STATUS_ENDED {
+func (p *Plugin) handleStandardWebhook(w http.ResponseWriter, r *http.Request, webhook *zoom.Webhook) {
+	if webhook.Status != zoom.WEBHOOK_STATUS_ENDED {
 		return
 	}
 
@@ -114,7 +114,7 @@ func (p *Plugin) handleStandardWebhook(w http.ResponseWriter, r *http.Request, w
 	}
 
 	post.Message = "Meeting has ended."
-	post.Props["meeting_status"] = zd.WEBHOOK_STATUS_ENDED
+	post.Props["meeting_status"] = zoom.WEBHOOK_STATUS_ENDED
 
 	if _, err := p.API.UpdatePost(post); err != nil {
 		http.Error(w, err.Error(), err.StatusCode)
@@ -175,8 +175,8 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 	if meetingId == 0 {
 		personal = false
 
-		meeting := &zd.Meeting{
-			Type:  zd.MEETING_TYPE_INSTANT,
+		meeting := &zoom.Meeting{
+			Type:  zoom.MEETING_TYPE_INSTANT,
 			Topic: req.Topic,
 		}
 
@@ -203,7 +203,7 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 		Props: map[string]interface{}{
 			"meeting_id":        meetingId,
 			"meeting_link":      meetingUrl,
-			"meeting_status":    zd.WEBHOOK_STATUS_STARTED,
+			"meeting_status":    zoom.WEBHOOK_STATUS_STARTED,
 			"meeting_personal":  personal,
 			"meeting_topic":     req.Topic,
 			"from_webhook":      "true",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zoom",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -14,7 +14,7 @@ export function startMeeting(channelId) {
             if (error.response && error.response.text) {
                 const e = JSON.parse(error.response.text);
                 if (e && e.message) {
-                    m = 'Zoom error: ' + e.message;
+                    m += '\nZoom error: ' + e.message;
                 }
             }
             const post = {
@@ -37,13 +37,8 @@ export function startMeeting(channelId) {
             };
 
             dispatch({
-                type: PostTypes.RECEIVED_POSTS,
-                data: {
-                    order: [],
-                    posts: {
-                        [post.id]: post,
-                    },
-                },
+                type: PostTypes.RECEIVED_NEW_POST,
+                data: post,
                 channelId,
             });
 


### PR DESCRIPTION
#### Summary
- We were importing the local go package a little incorrectly, causing us to import our own package from github (instead of just using the files in the local tree). This meant that we were using version 1.0.3 of that 'package', while the rest of the plugin was currently at 1.0.6.
- Also, redux was changed a bit back in 2019-04-15 and the action we were using was out of date.

Error looks like this:
![image](https://user-images.githubusercontent.com/1490756/59055994-29733000-8865-11e9-8450-60db82f92036.png)

#### Links
Fixes: [MM-15960](https://mattermost.atlassian.net/browse/MM-15960)