### PR TITLE
Implemented '/zoom start' command as an alternative to the zoom button

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,5 +23,8 @@ require (
 	google.golang.org/grpc v1.22.0 // indirect
 )
 
-// Workaround for https://github.com/golang/go/issues/30831 and fallout.
-replace github.com/golang/lint => github.com/golang/lint v0.0.0-20190227174305-8f45f776aaf1
+replace (
+	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
+	// Workaround for https://github.com/golang/go/issues/30831 and fallout.
+	github.com/golang/lint => github.com/golang/lint v0.0.0-20190227174305-8f45f776aaf1
+)

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ cloud.google.com/go v0.31.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.37.1/go.mod h1:SAbnLi6YTSPKSI0dTUEOVLCkyPfKXK8n4ibqiMoj4ok=
 contrib.go.opencensus.io/exporter/ocagent v0.4.9/go.mod h1:ueLzZcP7LPhPulEBukGn4aLh7Mx9YJwpVJ9nL2FYltw=
-git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/Azure/azure-sdk-for-go v26.5.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v11.5.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
@@ -18,6 +16,7 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -177,8 +176,6 @@ github.com/mattermost/go-i18n v1.1.2 h1:iyIztdnCePILpzW1nsZSLQtqhtI6M5E3OS6IkFv/
 github.com/mattermost/go-i18n v1.1.2/go.mod h1:RyS7FDNQlzF1PsjbJWHRI35exqaKGSO9qD4iv8QjE34=
 github.com/mattermost/gorp v2.0.1-0.20190301154413-3b31e9a39d05+incompatible h1:FN4zK2wNig7MVVsOsGEZ+LeIq0gUcudn3LEGgbodMq8=
 github.com/mattermost/gorp v2.0.1-0.20190301154413-3b31e9a39d05+incompatible/go.mod h1:0kX1qa3DOpaPJyOdMLeo7TcBN0QmUszj9a/VygOhDe0=
-github.com/mattermost/mattermost-server v5.11.1+incompatible h1:LPzKY0+2Tic/ik67qIg6VrydRCgxNXZQXOeaiJ2rMBY=
-github.com/mattermost/mattermost-server v5.11.1+incompatible/go.mod h1:5L6MjAec+XXQwMIt791Ganu45GKsSiM+I0tLR9wUj8Y=
 github.com/mattermost/mattermost-server v5.12.0+incompatible h1:Glsf3vGsceqzaDa9BQfO5Wsj0cNxagwuBhy3pCN/AT0=
 github.com/mattermost/mattermost-server v5.12.0+incompatible/go.mod h1:O3Tfw/SymCK+cYdFSMjQZyP4VndjcfVeT6ZoJjglByw=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
@@ -203,7 +200,6 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/muesli/smartcrop v0.2.1-0.20181030220600-548bbf0c0965/go.mod h1:i2fCI/UorTfgEpPPLWiFBv4pye+YAG78RwcQLUkocpI=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
-github.com/nicksnyder/go-i18n v2.0.2+incompatible h1:Xt6dluut3s2zBUha8/3sj6atWMQbFioi9OMqUGH9khg=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=

--- a/server/command.go
+++ b/server/command.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost-plugin-zoom/server/zoom"
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/plugin"
+)
+
+const COMMAND_HELP = `* |/zoom start| - Start a zoom meeting.`
+
+func getCommand() *model.Command {
+	return &model.Command{
+		Trigger:          "zoom",
+		DisplayName:      "Zoom",
+		Description:      "Integration with Zoom.",
+		AutoComplete:     true,
+		AutoCompleteDesc: "Available commands: start",
+		AutoCompleteHint: "[command]",
+	}
+}
+
+func (p *Plugin) postCommandResponse(args *model.CommandArgs, text string) {
+	post := &model.Post{
+		UserId:    p.botUserID,
+		ChannelId: args.ChannelId,
+		Message:   text,
+	}
+	_ = p.API.SendEphemeralPost(args.UserId, post)
+}
+
+func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	config := p.getConfiguration()
+
+	split := strings.Fields(args.Command)
+	command := split[0]
+	action := ""
+
+	if command != "/zoom" {
+		return &model.CommandResponse{}, nil
+	}
+
+	if len(split) > 1 {
+		action = split[1]
+	} else {
+		p.postCommandResponse(args, "Please specify an action for /zoom command.")
+		return &model.CommandResponse{}, nil
+	}
+
+	userID := args.UserId
+	user, appErr := p.API.GetUser(userID)
+
+	if appErr != nil {
+		p.postCommandResponse(args, fmt.Sprintf("We could not retrieve user (userId: %v)", args.UserId))
+		return &model.CommandResponse{}, nil
+	}
+
+	if action == "start" {
+
+		if _, appErr = p.API.GetChannelMember(args.ChannelId, userID); appErr != nil {
+			p.postCommandResponse(args, fmt.Sprintf("We could not get channel members (channelId: %v)", args.ChannelId))
+			return &model.CommandResponse{}, nil
+		}
+
+		meetingID := 0
+		personal := false
+
+		// Determine if the user is sending command in DM or channel
+		channel, tmpErr := p.API.GetChannel(args.ChannelId)
+		if tmpErr != nil {
+			p.postCommandResponse(args, fmt.Sprintf("We could not get channel members (channelId: %v)", args.ChannelId))
+			return &model.CommandResponse{}, nil
+		}
+
+		if channel.Type == "D" {
+			// create a personal zoom meeting
+			personal = true
+			ru, clientErr := p.zoomClient.GetUser(user.Email)
+			if clientErr != nil {
+				p.postCommandResponse(args, "We could not verify your Mattermost account in Zoom. Please ensure that your Mattermost email address matches your Zoom email address.")
+				return &model.CommandResponse{}, nil
+			}
+			meetingID = ru.Pmi
+		} else {
+			// create a channel zoom meeting
+			meeting := &zoom.Meeting{
+				Type: zoom.MeetingTypeInstant,
+			}
+
+			rm, clientErr := p.zoomClient.CreateMeeting(meeting, user.Email)
+			if clientErr != nil {
+				p.postCommandResponse(args, "We could not create and start a meeting in Zoom. Please ensure that your Mattermost email address matches your Zoom email address.")
+				return &model.CommandResponse{}, nil
+			}
+			meetingID = rm.ID
+		}
+
+		zoomURL := strings.TrimSpace(config.ZoomURL)
+		if len(zoomURL) == 0 {
+			zoomURL = "https://zoom.us"
+		}
+
+		meetingURL := fmt.Sprintf("%s/j/%v", zoomURL, meetingID)
+
+		post := &model.Post{
+			UserId:    p.botUserID,
+			ChannelId: args.ChannelId,
+			Message:   fmt.Sprintf("Meeting started at %s.", meetingURL),
+			Type:      "custom_zoom",
+			Props: map[string]interface{}{
+				"meeting_id":       meetingID,
+				"meeting_link":     meetingURL,
+				"meeting_status":   zoom.WebhookStatusStarted,
+				"meeting_personal": personal,
+			},
+		}
+
+		_, appErr := p.API.CreatePost(post)
+		if appErr != nil {
+			p.postCommandResponse(args, appErr.Error())
+			return &model.CommandResponse{}, nil
+		}
+	} else {
+		p.postCommandResponse(args, fmt.Sprintf("Unknown action %v", action))
+	}
+
+	return &model.CommandResponse{}, nil
+}

--- a/server/command.go
+++ b/server/command.go
@@ -31,7 +31,7 @@ func (p *Plugin) postCommandResponse(args *model.CommandArgs, text string) {
 	_ = p.API.SendEphemeralPost(args.UserId, post)
 }
 
-func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (string, error) {
 	config := p.getConfiguration()
 
 	split := strings.Fields(args.Command)

--- a/server/command.go
+++ b/server/command.go
@@ -125,12 +125,12 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 }
 
 func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
-	msg, err := executeCommand(c, args)
+	msg, err := p.executeCommand(c, args)
 	if err != nil {
-		p.LogWarn("failed to execute command", "error", err.Error())
+		p.API.LogWarn("failed to execute command", "error", err.Error())
 	}
-	if msg != "" {
-		p.postCommandResponse(args, msg)
+	if msg.Text != "" {
+		p.postCommandResponse(args, msg.Text)
 	}
 	return &model.CommandResponse{}, nil
 }

--- a/server/command.go
+++ b/server/command.go
@@ -39,7 +39,7 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 	action := ""
 
 	if command != "/zoom" {
-		return &model.CommandResponse{}, nil
+		return fmt.Sprintf("Command '%s' is not /zoom. Please try again.", command), nil
 	}
 
 	if len(split) > 1 {
@@ -53,13 +53,13 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 	user, appErr := p.API.GetUser(userID)
 	if appErr != nil {
 		p.postCommandResponse(args, fmt.Sprintf("We could not retrieve user (userId: %v)", args.UserId))
-		return &model.CommandResponse{}, nil
+		return fmt.Sprintf("We could not retrieve user (userId: %v)", args.UserId), nil
 	}
 
 	if action == "start" {
 		if _, appErr = p.API.GetChannelMember(args.ChannelId, userID); appErr != nil {
 			p.postCommandResponse(args, fmt.Sprintf("We could not get channel members (channelId: %v)", args.ChannelId))
-			return &model.CommandResponse{}, nil
+			return fmt.Sprintf("We could not get channel members (channelId: %v)", args.ChannelId), nil
 		}
 
 		meetingID := 0
@@ -69,7 +69,7 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 		channel, tmpErr := p.API.GetChannel(args.ChannelId)
 		if tmpErr != nil {
 			p.postCommandResponse(args, fmt.Sprintf("We could not get channel members (channelId: %v)", args.ChannelId))
-			return &model.CommandResponse{}, nil
+			return fmt.Sprintf("We could not get channel members (channelId: %v)", args.ChannelId), nil
 		}
 
 		if channel.Type == "D" {
@@ -78,7 +78,7 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 			ru, clientErr := p.zoomClient.GetUser(user.Email)
 			if clientErr != nil {
 				p.postCommandResponse(args, "We could not verify your Mattermost account in Zoom. Please ensure that your Mattermost email address matches your Zoom login email address.")
-				return &model.CommandResponse{}, nil
+				return "We could not verify your Mattermost account in Zoom. Please ensure that your Mattermost email address matches your Zoom login email address.", nil
 			}
 			meetingID = ru.Pmi
 		} else {
@@ -90,7 +90,7 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 			rm, clientErr := p.zoomClient.CreateMeeting(meeting, user.Email)
 			if clientErr != nil {
 				p.postCommandResponse(args, "We could not create and start a meeting in Zoom. Please ensure that your Mattermost email address matches your Zoom login email address.")
-				return &model.CommandResponse{}, nil
+				return "We could not create and start a meeting in Zoom. Please ensure that your Mattermost email address matches your Zoom login email address.", nil
 			}
 			meetingID = rm.ID
 		}
@@ -118,10 +118,10 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 		_, appErr := p.API.CreatePost(post)
 		if appErr != nil {
 			p.postCommandResponse(args, "Failed to post message. Please try again.")
-			return &model.CommandResponse{}, nil
+			return "Failed to post message. Please try again.", nil
 		}
 	}
-	return &model.CommandResponse{}, nil
+	return "", nil
 }
 
 func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
@@ -129,8 +129,8 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 	if err != nil {
 		p.API.LogWarn("failed to execute command", "error", err.Error())
 	}
-	if msg.Text != "" {
-		p.postCommandResponse(args, msg.Text)
+	if msg != "" {
+		p.postCommandResponse(args, msg)
 	}
 	return &model.CommandResponse{}, nil
 }

--- a/server/command.go
+++ b/server/command.go
@@ -79,7 +79,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			personal = true
 			ru, clientErr := p.zoomClient.GetUser(user.Email)
 			if clientErr != nil {
-				p.postCommandResponse(args, "We could not verify your Mattermost account in Zoom. Please ensure that your Mattermost email address matches your Zoom email address.")
+				p.postCommandResponse(args, "We could not verify your Mattermost account in Zoom. Please ensure that your Mattermost email address matches your Zoom login email address.")
 				return &model.CommandResponse{}, nil
 			}
 			meetingID = ru.Pmi
@@ -91,7 +91,7 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 
 			rm, clientErr := p.zoomClient.CreateMeeting(meeting, user.Email)
 			if clientErr != nil {
-				p.postCommandResponse(args, "We could not create and start a meeting in Zoom. Please ensure that your Mattermost email address matches your Zoom email address.")
+				p.postCommandResponse(args, "We could not create and start a meeting in Zoom. Please ensure that your Mattermost email address matches your Zoom login email address.")
 				return &model.CommandResponse{}, nil
 			}
 			meetingID = rm.ID

--- a/server/command.go
+++ b/server/command.go
@@ -133,3 +133,4 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 		p.postCommandResponse(args, msg)
 	}
 	return &model.CommandResponse{}, nil
+}

--- a/server/command.go
+++ b/server/command.go
@@ -113,8 +113,9 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 		if appErr != nil {
 			return "Failed to post message. Please try again.", nil
 		}
+		return "", nil
 	}
-	return "", nil
+	return fmt.Sprintf("Unknown action %v", action), nil
 }
 
 func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {

--- a/server/command.go
+++ b/server/command.go
@@ -45,20 +45,17 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 	if len(split) > 1 {
 		action = split[1]
 	} else {
-		p.postCommandResponse(args, "Please specify an action for /zoom command.")
 		return "Please specify an action for /zoom command.", nil
 	}
 
 	userID := args.UserId
 	user, appErr := p.API.GetUser(userID)
 	if appErr != nil {
-		p.postCommandResponse(args, fmt.Sprintf("We could not retrieve user (userId: %v)", args.UserId))
 		return fmt.Sprintf("We could not retrieve user (userId: %v)", args.UserId), nil
 	}
 
 	if action == "start" {
 		if _, appErr = p.API.GetChannelMember(args.ChannelId, userID); appErr != nil {
-			p.postCommandResponse(args, fmt.Sprintf("We could not get channel members (channelId: %v)", args.ChannelId))
 			return fmt.Sprintf("We could not get channel members (channelId: %v)", args.ChannelId), nil
 		}
 
@@ -68,7 +65,6 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 		// Determine if the user is sending command in DM or channel
 		channel, tmpErr := p.API.GetChannel(args.ChannelId)
 		if tmpErr != nil {
-			p.postCommandResponse(args, fmt.Sprintf("We could not get channel members (channelId: %v)", args.ChannelId))
 			return fmt.Sprintf("We could not get channel members (channelId: %v)", args.ChannelId), nil
 		}
 
@@ -77,7 +73,6 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 			personal = true
 			ru, clientErr := p.zoomClient.GetUser(user.Email)
 			if clientErr != nil {
-				p.postCommandResponse(args, "We could not verify your Mattermost account in Zoom. Please ensure that your Mattermost email address matches your Zoom login email address.")
 				return "We could not verify your Mattermost account in Zoom. Please ensure that your Mattermost email address matches your Zoom login email address.", nil
 			}
 			meetingID = ru.Pmi
@@ -89,7 +84,6 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 
 			rm, clientErr := p.zoomClient.CreateMeeting(meeting, user.Email)
 			if clientErr != nil {
-				p.postCommandResponse(args, "We could not create and start a meeting in Zoom. Please ensure that your Mattermost email address matches your Zoom login email address.")
 				return "We could not create and start a meeting in Zoom. Please ensure that your Mattermost email address matches your Zoom login email address.", nil
 			}
 			meetingID = rm.ID
@@ -117,7 +111,6 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 
 		_, appErr := p.API.CreatePost(post)
 		if appErr != nil {
-			p.postCommandResponse(args, "Failed to post message. Please try again.")
 			return "Failed to post message. Please try again.", nil
 		}
 	}

--- a/server/command.go
+++ b/server/command.go
@@ -46,7 +46,7 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 		action = split[1]
 	} else {
 		p.postCommandResponse(args, "Please specify an action for /zoom command.")
-		return &model.CommandResponse{}, nil
+		return "Please specify an action for /zoom command.", nil
 	}
 
 	userID := args.UserId

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -60,6 +60,10 @@ func (p *Plugin) OnActivate() error {
 		return errors.Wrap(err, "couldn't get bundle path")
 	}
 
+	if err = p.API.RegisterCommand(getCommand()); err != nil {
+		return errors.WithMessage(err, "OnActivate: failed to register command")
+	}
+
 	profileImage, err := ioutil.ReadFile(filepath.Join(bundlePath, "assets", "profile.png"))
 	if err != nil {
 		return errors.Wrap(err, "couldn't read profile image")

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -122,6 +122,7 @@ func TestPlugin(t *testing.T) {
 			require.Nil(t, err)
 			api.On("GetBundlePath").Return(path, nil)
 			api.On("SetProfileImage", botUserID, mock.Anything).Return(nil)
+			api.On("RegisterCommand", mock.AnythingOfType("*model.Command")).Return(nil)
 
 			p := Plugin{}
 			p.setConfiguration(&configuration{


### PR DESCRIPTION
Summary:
- Mobile app users does not have the zoom start button and would be great to have the option of the `/zoom start` command to start a zoom meeting.

Fixes https://github.com/mattermost/mattermost-plugin-zoom/issues/31