### PR TITLE
MM-19716 - Fix guard condition to update meeting to Ended status

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -61,7 +61,7 @@ func (p *Plugin) handleWebhook(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *Plugin) handleStandardWebhook(w http.ResponseWriter, r *http.Request, webhook *zoom.Webhook) {
-	if webhook.Status != zoom.WebhookStatusStarted {
+	if webhook.Status != zoom.WebhookStatusEnded {
 		return
 	}
 


### PR DESCRIPTION
#### Summary

Fix guard condition to only update meeting to Ended status when receiving a webhook event for `WebhookStatusEnded` status. This was causing the meeting post to update to ended when the meeting was started. This was regression caused by: https://github.com/mattermost/mattermost-plugin-zoom/pull/29

#### Ticket Link

[MM-19716](https://mattermost.atlassian.net/browse/MM-19716)



