### PR TITLE
[MM-18201] Use mattermost-redux to handle csrf issues

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -802,6 +802,12 @@
         "regenerator-runtime": "^0.13.2"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.13.2",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
@@ -944,6 +950,11 @@
         "lodash": "^4.17.11",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@react-native-community/netinfo": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-4.6.0.tgz",
+      "integrity": "sha512-wz39BUpExDU1kTpLlBkDwwb0Efg+uuwixToosTSarZgpzG/CmcRvWdD786TMiE5tLDd+Mpi2xh3w4FrVM8zjoA=="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -1375,6 +1386,13 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+        }
       }
     },
     "balanced-match": {
@@ -1970,9 +1988,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
+      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
     },
     "core-js-compat": {
       "version": "3.1.4",
@@ -4596,26 +4614,47 @@
       }
     },
     "mattermost-redux": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/mattermost-redux/-/mattermost-redux-5.12.0.tgz",
-      "integrity": "sha512-JksLQ+nX7e4ISTshAjovofQzezRIkoJRjy5EESewR3H6UuEYsTrCp9EgtP5epK+cI2juQ+TAtclLdyUSZZnrZQ==",
+      "version": "github:mattermost/mattermost-redux#40e5bd5a18daa919c62a06b360aa27f2e6ed3e13",
+      "from": "github:mattermost/mattermost-redux#40e5bd5a18daa919c62a06b360aa27f2e6ed3e13",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "3.0.0",
-        "form-data": "2.3.3",
+        "form-data": "2.5.0",
         "gfycat-sdk": "1.4.18",
         "harmony-reflect": "1.6.1",
         "isomorphic-fetch": "2.2.1",
         "mime-db": "1.40.0",
-        "redux": "4.0.1",
+        "moment-timezone": "0.5.26",
+        "redux": "4.0.4",
         "redux-action-buffer": "1.2.0",
         "redux-batched-actions": "0.4.1",
-        "redux-offline": "git+https://github.com/enahum/redux-offline.git#4bd85e7e3b279a2b11fb4d587808d583d2b5e7b5",
+        "redux-offline": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
         "redux-persist": "4.9.1",
         "redux-thunk": "2.3.0",
         "reselect": "4.0.0",
         "serialize-error": "2.1.0",
         "shallow-equals": "1.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz",
+          "integrity": "sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "redux": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
+          "integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "symbol-observable": "^1.2.0"
+          }
+        }
       }
     },
     "md5.js": {
@@ -4787,6 +4826,19 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "moment-timezone": {
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.26.tgz",
+      "integrity": "sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==",
+      "requires": {
+        "moment": ">= 2.9.0"
       }
     },
     "move-concurrently": {
@@ -5696,9 +5748,10 @@
       "integrity": "sha512-r6tLDyBP3U9cXNLEHs0n1mX5TQfmk6xE0Y9uinYZ5HOyAWDgIJxYqRRkU/bC6XrJ4nS7tasNbxaHJHVmf9UdkA=="
     },
     "redux-offline": {
-      "version": "git+https://github.com/enahum/redux-offline.git#4bd85e7e3b279a2b11fb4d587808d583d2b5e7b5",
-      "from": "git+https://github.com/enahum/redux-offline.git#4bd85e7e3b279a2b11fb4d587808d583d2b5e7b5",
+      "version": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
+      "from": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
       "requires": {
+        "@react-native-community/netinfo": "^4.1.3",
         "redux-persist": "^4.5.0"
       }
     },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1333,6 +1333,11 @@
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
     },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1459,8 +1464,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-      "dev": true
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "big.js": {
       "version": "5.2.2",
@@ -1838,6 +1842,11 @@
         }
       }
     },
+    "clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -1886,7 +1895,8 @@
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1961,11 +1971,6 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -2108,6 +2113,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -2123,11 +2129,6 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
-    },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -2589,11 +2590,6 @@
         }
       }
     },
-    "eslint-plugin-header": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.0.0.tgz",
-      "integrity": "sha512-OIu2ciVW8jK4Ove4JHm1I7X0C98PZuLCyCsoUhAm2HpyGS+zr34qLM6iV06unnDvssvvEh5BkOfaLRF+N7cGoQ=="
-    },
     "eslint-plugin-import": {
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.0.tgz",
@@ -2945,11 +2941,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fast-safe-stringify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
-    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -3093,21 +3084,6 @@
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
-    "formidable": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -3770,6 +3746,11 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-params": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/get-params/-/get-params-0.1.2.tgz",
+      "integrity": "sha1-uuDfq6WIoMYNeDTA2Nwv9g7u8v4="
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -3872,13 +3853,7 @@
     "graceful-fs": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
-      "dev": true
-    },
-    "harmony-reflect": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
-      "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA=="
+      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
     },
     "has": {
       "version": "1.0.3",
@@ -4004,8 +3979,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -4042,8 +4016,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "inflight": {
       "version": "1.0.6",
@@ -4058,7 +4031,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -4393,6 +4367,11 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsan": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/jsan/-/jsan-3.1.13.tgz",
+      "integrity": "sha512-9kGpCsGHifmw6oJet+y8HaCl14y7qgAsxVdV3pCHDySNR3BfDC30zgkssd7x5LRVAT22dnpbe9JdzzmXZnq9/g=="
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -4473,6 +4452,11 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
+    },
+    "linked-list": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/linked-list/-/linked-list-0.1.0.tgz",
+      "integrity": "sha1-eYsP+X0bkqT9CEgPVa6k6dSdN78="
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -4614,32 +4598,29 @@
       }
     },
     "mattermost-redux": {
-      "version": "github:mattermost/mattermost-redux#40e5bd5a18daa919c62a06b360aa27f2e6ed3e13",
-      "from": "github:mattermost/mattermost-redux#40e5bd5a18daa919c62a06b360aa27f2e6ed3e13",
+      "version": "github:mattermost/mattermost-redux#b56e7e3a6f7f5de281fd3541eefec9345a8bbc89",
+      "from": "github:mattermost/mattermost-redux#b56e7e3a6f7f5de281fd3541eefec9345a8bbc89",
       "requires": {
-        "deep-equal": "1.0.1",
-        "eslint-plugin-header": "3.0.0",
-        "form-data": "2.5.0",
+        "form-data": "2.5.1",
         "gfycat-sdk": "1.4.18",
-        "harmony-reflect": "1.6.1",
         "isomorphic-fetch": "2.2.1",
-        "mime-db": "1.40.0",
         "moment-timezone": "0.5.26",
         "redux": "4.0.4",
         "redux-action-buffer": "1.2.0",
-        "redux-batched-actions": "0.4.1",
         "redux-offline": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
         "redux-persist": "4.9.1",
+        "redux-persist-node-storage": "2.0.0",
         "redux-thunk": "2.3.0",
+        "remote-redux-devtools": "0.5.16",
         "reselect": "4.0.0",
-        "serialize-error": "2.1.0",
+        "serialize-error": "5.0.0",
         "shallow-equals": "1.0.0"
       },
       "dependencies": {
         "form-data": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz",
-          "integrity": "sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==",
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -4693,11 +4674,6 @@
       "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
       "dev": true
     },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -4729,22 +4705,17 @@
         "brorand": "^1.0.1"
       }
     },
-    "mime": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
-    },
     "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
     },
     "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "version": "2.1.25",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
       "requires": {
-        "mime-db": "1.40.0"
+        "mime-db": "1.42.0"
       }
     },
     "mimic-fn": {
@@ -4858,7 +4829,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -4872,6 +4844,11 @@
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
+    },
+    "nanoid": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.6.tgz",
+      "integrity": "sha512-2NDzpiuEy3+H0AVtdt8LoFi7PnqkOnIzYmJQp7xsEU6VexLluHQwKREuiz57XaQC5006seIadPrIZJhyS2n7aw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4982,6 +4959,14 @@
             }
           }
         }
+      }
+    },
+    "node-localstorage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
+      "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
+      "requires": {
+        "write-file-atomic": "^1.1.4"
       }
     },
     "node-releases": {
@@ -5531,16 +5516,10 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
-    "qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -5681,16 +5660,6 @@
         }
       }
     },
-    "readable-stream": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-      "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
     "readdirp": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
@@ -5742,10 +5711,26 @@
       "resolved": "https://registry.npmjs.org/redux-action-buffer/-/redux-action-buffer-1.2.0.tgz",
       "integrity": "sha1-LsCh2JnMn29EzN60Me5SrUHdl1U="
     },
-    "redux-batched-actions": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/redux-batched-actions/-/redux-batched-actions-0.4.1.tgz",
-      "integrity": "sha512-r6tLDyBP3U9cXNLEHs0n1mX5TQfmk6xE0Y9uinYZ5HOyAWDgIJxYqRRkU/bC6XrJ4nS7tasNbxaHJHVmf9UdkA=="
+    "redux-devtools-core": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/redux-devtools-core/-/redux-devtools-core-0.2.1.tgz",
+      "integrity": "sha512-RAGOxtUFdr/1USAvxrWd+Gq/Euzgw7quCZlO5TgFpDfG7rB5tMhZUrNyBjpzgzL2yMk0eHnPYIGm7NkIfRzHxQ==",
+      "requires": {
+        "get-params": "^0.1.2",
+        "jsan": "^3.1.13",
+        "lodash": "^4.17.11",
+        "nanoid": "^2.0.0",
+        "remotedev-serialize": "^0.1.8"
+      }
+    },
+    "redux-devtools-instrument": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.9.6.tgz",
+      "integrity": "sha512-MwvY4cLEB2tIfWWBzrUR02UM9qRG2i7daNzywRvabOSVdvAY7s9BxSwMmVRH1Y/7QWjplNtOwgT0apKhHg2Qew==",
+      "requires": {
+        "lodash": "^4.2.0",
+        "symbol-observable": "^1.0.2"
+      }
     },
     "redux-offline": {
       "version": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
@@ -5763,6 +5748,14 @@
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.4",
         "lodash-es": "^4.17.4"
+      }
+    },
+    "redux-persist-node-storage": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist-node-storage/-/redux-persist-node-storage-2.0.0.tgz",
+      "integrity": "sha1-QAHjK4tDxzgH7y2pujAfSxxmr3k=",
+      "requires": {
+        "node-localstorage": "^1.3.0"
       }
     },
     "redux-thunk": {
@@ -5856,6 +5849,27 @@
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
+      }
+    },
+    "remote-redux-devtools": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/remote-redux-devtools/-/remote-redux-devtools-0.5.16.tgz",
+      "integrity": "sha512-xZ2D1VRIWzat5nsvcraT6fKEX9Cfi+HbQBCwzNnUAM8Uicm/anOc60XGalcaDPrVmLug7nhDl2nimEa3bL3K9w==",
+      "requires": {
+        "jsan": "^3.1.13",
+        "querystring": "^0.2.0",
+        "redux-devtools-core": "^0.2.1",
+        "redux-devtools-instrument": "^1.9.4",
+        "rn-host-detect": "^1.1.5",
+        "socketcluster-client": "^14.2.1"
+      }
+    },
+    "remotedev-serialize": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/remotedev-serialize/-/remotedev-serialize-0.1.8.tgz",
+      "integrity": "sha512-3YG/FDcOmiK22bl5oMRM8RRnbGrFEuPGjbcDG+z2xi5aQaNQNZ8lqoRnZTwXVfaZtutXuiAQOgPRrogzQk8edg==",
+      "requires": {
+        "jsan": "^3.1.13"
       }
     },
     "remove-trailing-separator": {
@@ -5989,6 +6003,11 @@
         "inherits": "^2.0.1"
       }
     },
+    "rn-host-detect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rn-host-detect/-/rn-host-detect-1.2.0.tgz",
+      "integrity": "sha512-btNg5kzHcjZZ7t7mvvV/4wNJ9e3MPgrWivkRgWURzXL0JJ0pwWlU4zrbmdlz3HHzHOxhBhHB4D+/dbMFfu4/4A=="
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -6019,7 +6038,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -6034,6 +6054,31 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sc-channel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.2.0.tgz",
+      "integrity": "sha512-M3gdq8PlKg0zWJSisWqAsMmTVxYRTpVRqw4CWAdKBgAfVKumFcTjoCV0hYu7lgUXccCtCD8Wk9VkkE+IXCxmZA==",
+      "requires": {
+        "component-emitter": "1.2.1"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        }
+      }
+    },
+    "sc-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-2.0.1.tgz",
+      "integrity": "sha512-JoVhq3Ud+3Ujv2SIG7W0XtjRHsrNgl6iXuHHsh0s+Kdt5NwI6N2EGAZD4iteitdDv68ENBkpjtSvN597/wxPSQ=="
+    },
+    "sc-formatter": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sc-formatter/-/sc-formatter-3.0.2.tgz",
+      "integrity": "sha512-9PbqYBpCq+OoEeRQ3QfFIGE6qwjjBcd2j7UjgDlhnZbtSnuGgHdcRklPKYGuYFH82V/dwd+AIpu8XvA1zqTd+A=="
     },
     "scheduler": {
       "version": "0.13.6",
@@ -6058,12 +6103,16 @@
     "semver": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-      "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+      "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+      "dev": true
     },
     "serialize-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
+      "integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
+      "requires": {
+        "type-fest": "^0.8.0"
+      }
     },
     "serialize-javascript": {
       "version": "1.7.0",
@@ -6158,6 +6207,11 @@
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
       }
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -6278,6 +6332,39 @@
           "requires": {
             "is-buffer": "^1.1.5"
           }
+        }
+      }
+    },
+    "socketcluster-client": {
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-14.3.1.tgz",
+      "integrity": "sha512-Sd/T0K/9UlqTfz+HUuFq90dshA5OBJPQbdkRzGtcKIOm52fkdsBTt0FYpiuzzxv5VrU7PWpRm6KIfNXyPwlLpw==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "clone": "2.1.1",
+        "component-emitter": "1.2.1",
+        "linked-list": "0.1.0",
+        "querystring": "0.2.0",
+        "sc-channel": "^1.2.0",
+        "sc-errors": "^2.0.1",
+        "sc-formatter": "^3.0.1",
+        "uuid": "3.2.1",
+        "ws": "7.1.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
         }
       }
     },
@@ -6512,6 +6599,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
       "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -6542,24 +6630,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
-    },
-    "superagent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.1.0.tgz",
-      "integrity": "sha512-7V6JVx5N+eTL1MMqRBX0v0bG04UjrjAvvZJTF/VDH/SH2GjSLqlrcYepFlpTrXpm37aSY6h3GGVWGxXl/98TKA==",
-      "requires": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.2",
-        "debug": "^4.1.1",
-        "fast-safe-stringify": "^2.0.6",
-        "form-data": "^2.3.3",
-        "formidable": "^1.2.1",
-        "methods": "^1.1.2",
-        "mime": "^2.4.4",
-        "qs": "^6.7.0",
-        "readable-stream": "^3.4.0",
-        "semver": "^6.1.1"
-      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -6813,6 +6883,11 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -6982,7 +7057,13 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "v8-compile-cache": {
       "version": "2.0.3",
@@ -7297,6 +7378,24 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
+      }
+    },
+    "ws": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.0.tgz",
+      "integrity": "sha512-Swie2C4fs7CkwlHu1glMePLYJJsWjzhl1vm3ZaLplD0h7OMkZyZ6kLTB/OagiU923bZrPFXuDTeEqaEN4NWG4g==",
+      "requires": {
+        "async-limiter": "^1.0.0"
       }
     },
     "xtend": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -11,7 +11,8 @@
     "fix": "eslint --ignore-pattern node_modules --ignore-pattern dist --ext .js --ext .jsx . --quiet --fix"
   },
   "dependencies": {
-    "mattermost-redux": "5.12.0",
+    "core-js": "3.1.4",
+    "mattermost-redux": "github:mattermost/mattermost-redux#40e5bd5a18daa919c62a06b360aa27f2e6ed3e13",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-intl": "2.9.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -12,13 +12,12 @@
   },
   "dependencies": {
     "core-js": "3.1.4",
-    "mattermost-redux": "github:mattermost/mattermost-redux#40e5bd5a18daa919c62a06b360aa27f2e6ed3e13",
+    "mattermost-redux": "github:mattermost/mattermost-redux#b56e7e3a6f7f5de281fd3541eefec9345a8bbc89",
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-intl": "2.9.0",
     "react-redux": "5.0.7",
-    "redux": "4.0.1",
-    "superagent": "5.1.0"
+    "redux": "4.0.1"
   },
   "devDependencies": {
     "@babel/cli": "7.5.0",

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -11,9 +11,15 @@ export function startMeeting(channelId) {
             await Client.startMeeting(channelId, true);
         } catch (error) {
             let m = 'We could not verify your Mattermost account in Zoom. Please ensure that your Mattermost email address matches your Zoom email address.';
-            if (error.message) {
-                m += '\nZoom error: ' + error.message;
+            if (error.message && error.message[0] === '{') {
+                const e = JSON.parse(error.message);
+
+                // Error is from Zoom API
+                if (e && e.message) {
+                    m += '\nZoom error: ' + e.message;
+                }
             }
+
             const post = {
                 id: 'zoomPlugin' + Date.now(),
                 create_at: Date.now(),

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -11,11 +11,8 @@ export function startMeeting(channelId) {
             await Client.startMeeting(channelId, true);
         } catch (error) {
             let m = 'We could not verify your Mattermost account in Zoom. Please ensure that your Mattermost email address matches your Zoom email address.';
-            if (error.response && error.response.text) {
-                const e = JSON.parse(error.response.text);
-                if (e && e.message) {
-                    m += '\nZoom error: ' + e.message;
-                }
+            if (error.message) {
+                m += '\nZoom error: ' + error.message;
             }
             const post = {
                 id: 'zoomPlugin' + Date.now(),

--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -21,7 +21,7 @@ export const doPost = async (url, body, headers = {}) => {
         method: 'post',
         body: JSON.stringify(body),
         headers,
-    }
+    };
 
     const response = await fetch(url, Client4.getOptions(options));
 
@@ -36,4 +36,4 @@ export const doPost = async (url, body, headers = {}) => {
         status_code: response.status,
         url,
     });
-}
+};

--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -1,7 +1,8 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License for license information.
 
-import request from 'superagent';
+import {Client4} from 'mattermost-redux/client';
+import {ClientError} from 'mattermost-redux/client/client4';
 
 import {id} from '../manifest';
 
@@ -11,19 +12,33 @@ export default class Client {
     }
 
     startMeeting = async (channelId, personal = true, topic = '', meetingId = 0) => {
-        return this.doPost(`${this.url}/api/v1/meetings`, {channel_id: channelId, personal, topic, meeting_id: meetingId});
+        return doPost(`${this.url}/api/v1/meetings`, {channel_id: channelId, personal, topic, meeting_id: meetingId});
+    }
+}
+
+export const doPost = async (url, body, headers = {}) => {
+    const options = {
+        method: 'post',
+        body: JSON.stringify(body),
+        headers,
     }
 
-    doPost = async (url, body, headers = {}) => {
-        headers['X-Requested-With'] = 'XMLHttpRequest';
+    const response = await fetch(url, Client4.getOptions(options));
 
-        const response = await request.
-            post(url).
-            send(body).
-            set(headers).
-            type('application/json').
-            accept('application/json');
-
-        return response.body;
+    let data = await response.json();
+    if (response.ok) {
+        return data;
     }
+
+    // Error received is either a regular string, or json with the error message in data.message
+    let message = data || '';
+    if (data && data.message) {
+        message = data.message;
+    }
+
+    throw new ClientError(Client4.url, {
+        message,
+        status_code: response.status,
+        url,
+    });
 }

--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -25,19 +25,14 @@ export const doPost = async (url, body, headers = {}) => {
 
     const response = await fetch(url, Client4.getOptions(options));
 
-    let data = await response.json();
     if (response.ok) {
-        return data;
+        return response.json();
     }
 
-    // Error received is either a regular string, or json with the error message in data.message
-    let message = data || '';
-    if (data && data.message) {
-        message = data.message;
-    }
+    const text = await response.text();
 
     throw new ClientError(Client4.url, {
-        message,
+        message: text || '',
         status_code: response.status,
         url,
     });

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -32,6 +32,7 @@ module.exports = {
                                     edge: 42,
                                     safari: 12,
                                 },
+                                corejs: 3,
                                 modules: false,
                                 debug: false,
                                 useBuiltIns: 'usage',


### PR DESCRIPTION
#### Summary

This PR upgrades mattermost-redux to use `Client4.getOptions`, in order to correctly include the csrf token.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-18201

#### QA Steps

- Set `ServiceSettings.ExperimentalStrictCSRFEnforcement` to true in the server's config.json
- Verify that you can click the zoom button to begin a meeting