### PR TITLE
Add aria-label to start meeting button

### DIFF
--- a/webapp/src/components/icon.jsx
+++ b/webapp/src/components/icon.jsx
@@ -15,6 +15,7 @@ export default class Icon extends React.PureComponent {
             <span
                 style={style.iconStyle}
                 aria-hidden='true'
+                aria-label='Camera Icon'
                 dangerouslySetInnerHTML={{__html: Svgs.VIDEO_CAMERA}}
             />
         );

--- a/webapp/src/components/icon.jsx
+++ b/webapp/src/components/icon.jsx
@@ -2,7 +2,7 @@
 // See License for license information.
 
 import React from 'react';
-
+import {FormattedMessage} from 'react-intl';
 import {makeStyleFromTheme} from 'mattermost-redux/utils/theme_utils';
 
 import {Svgs} from '../constants';
@@ -12,12 +12,18 @@ export default class Icon extends React.PureComponent {
         const style = getStyle();
 
         return (
-            <span
-                style={style.iconStyle}
-                aria-hidden='true'
-                aria-label='Camera Icon'
-                dangerouslySetInnerHTML={{__html: Svgs.VIDEO_CAMERA}}
-            />
+            <FormattedMessage
+                id='zoom.camera.ariaLabel'
+                defaultMessage='camera icon'
+            >
+                {(ariaLabel) => (
+                    <span
+                        style={style.iconStyle}
+                        aria-label={ariaLabel}
+                        dangerouslySetInnerHTML={{__html: Svgs.VIDEO_CAMERA}}
+                    />
+                )}
+            </FormattedMessage>
         );
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Added a 'Video Icon' aria-label to start zoom meeting button

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Resolves #59
