### PR TITLE
Add more manifest metadata

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,6 +2,8 @@
     "id": "zoom",
     "name": "Zoom",
     "description": "Zoom audio and video conferencing plugin for Mattermost 5.2+.",
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-zoom",
+    "support_url": "https://github.com/mattermost/mattermost-plugin-zoom/issues",
     "version": "1.2.0",
     "min_server_version": "5.12.0",
     "server": {


### PR DESCRIPTION
#### Summary
Add `homepage_url` and `support_url` to the manifest. `support_url` is not jet used in the webapp, but there is no downside of defining it already.

I've tested the changes locally and can confirm that the link to the `homepage_url` is correctly shown.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21918
