### PR TITLE
bump plugin from `v1.1.2` -> `v1.3.0`

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "zoom",
     "name": "Zoom",
     "description": "Zoom audio and video conferencing plugin for Mattermost 5.2+.",
-    "version": "1.1.2",
+    "version": "1.3.0",
     "min_server_version": "5.12.0",
     "server": {
         "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	Id:      "zoom",
-	Version: "1.1.2",
+	Version: "1.3.0",
 }

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,2 @@
 export const id = 'zoom';
-export const version = '1.1.2';
+export const version = '1.3.0';


### PR DESCRIPTION
#### Summary
This ticket "bumps" zoom to version v1.3.0, but at the same commit as tag `v1.1.2`.  The following steps were used.

* checkout commit eef5d68 (tagged `v1.1.2`)
* update version in plugin.json `v1.1.2` to `v1.3.0`
* make apply

