### PR TITLE
[MM-22638] Fix undefined name

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -59,13 +59,13 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 			return fmt.Sprintf("We could not get channel members (channelId: %v)", args.ChannelId), nil
 		}
 
-		recentMeeting, recentMeetingID, appErr := p.checkPreviousMessages(args.ChannelId)
+		recentMeeting, recentMeetingID, creatorName, appErr := p.checkPreviousMessages(args.ChannelId)
 		if appErr != nil {
 			return fmt.Sprintf("Error checking previous messages"), nil
 		}
 
 		if recentMeeting {
-			p.postConfirm(recentMeetingID, args.ChannelId, "", userID)
+			p.postConfirm(recentMeetingID, args.ChannelId, "", userID, creatorName)
 			return "", nil
 		}
 

--- a/server/http.go
+++ b/server/http.go
@@ -157,7 +157,7 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if forceCreate := r.URL.Query().Get("force"); forceCreate == "" {
-		recentMeeting, recentMeetindID, cpmErr := p.checkPreviousMessages(req.ChannelID)
+		recentMeeting, recentMeetindID, creatorName, cpmErr := p.checkPreviousMessages(req.ChannelID)
 		if cpmErr != nil {
 			http.Error(w, cpmErr.Error(), cpmErr.StatusCode)
 			return
@@ -167,7 +167,7 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 			if _, err := w.Write([]byte(`{"meeting_url": ""}`)); err != nil {
 				p.API.LogWarn("failed to write response", "error", err.Error())
 			}
-			p.postConfirm(recentMeetindID, req.ChannelID, req.Topic, userID)
+			p.postConfirm(recentMeetindID, req.ChannelID, req.Topic, userID, creatorName)
 			return
 		}
 	}
@@ -207,7 +207,7 @@ func (p *Plugin) getMeetingURL(meetingID int) string {
 	return fmt.Sprintf("%s/j/%v", zoomURL, meetingID)
 }
 
-func (p *Plugin) postConfirm(meetingID int, channelID string, topic string, userID string) *model.Post {
+func (p *Plugin) postConfirm(meetingID int, channelID string, topic string, userID string, creatorName string) *model.Post {
 	meetingURL := p.getMeetingURL(meetingID)
 
 	post := &model.Post{
@@ -216,31 +216,32 @@ func (p *Plugin) postConfirm(meetingID int, channelID string, topic string, user
 		Message:   "There is another recent meeting created on this channel.",
 		Type:      "custom_zoom",
 		Props: map[string]interface{}{
-			"type":             "custom_zoom",
-			"meeting_id":       meetingID,
-			"meeting_link":     meetingURL,
-			"meeting_status":   zoom.RecentlyCreated,
-			"meeting_personal": true,
-			"meeting_topic":    topic,
+			"type":                     "custom_zoom",
+			"meeting_id":               meetingID,
+			"meeting_link":             meetingURL,
+			"meeting_status":           zoom.RecentlyCreated,
+			"meeting_personal":         true,
+			"meeting_topic":            topic,
+			"meeting_creator_username": creatorName,
 		},
 	}
 
 	return p.API.SendEphemeralPost(userID, post)
 }
 
-func (p *Plugin) checkPreviousMessages(channelID string) (recentMeeting bool, meetindID int, err *model.AppError) {
+func (p *Plugin) checkPreviousMessages(channelID string) (recentMeeting bool, meetindID int, creatorName string, err *model.AppError) {
 	var zoomMeetingTimeWindow int64 = 30 // 30 seconds
 
 	postList, appErr := p.API.GetPostsSince(channelID, (time.Now().Unix()-zoomMeetingTimeWindow)*1000)
 	if appErr != nil {
-		return false, 0, appErr
+		return false, 0, "", appErr
 	}
 
 	for _, post := range postList.ToSlice() {
 		if meetingID, ok := post.Props["meeting_id"]; ok {
-			return true, int(meetingID.(float64)), nil
+			return true, int(meetingID.(float64)), post.Props["meeting_creator_username"].(string), nil
 		}
 	}
 
-	return false, 0, nil
+	return false, 0, "", nil
 }

--- a/webapp/src/components/post_type_zoom/index.js
+++ b/webapp/src/components/post_type_zoom/index.js
@@ -14,7 +14,7 @@ import PostTypeZoom from './post_type_zoom.jsx';
 function mapStateToProps(state, ownProps) {
     return {
         ...ownProps,
-        creatorName: ownProps.post.props.meeting_creator_username,
+        creatorName: ownProps.post.props.meeting_creator_username || "Someone",
         useMilitaryTime: getBool(state, 'display_settings', 'use_military_time', false),
         currentChannelId: getCurrentChannelId(state),
     };

--- a/webapp/src/components/post_type_zoom/index.js
+++ b/webapp/src/components/post_type_zoom/index.js
@@ -14,7 +14,7 @@ import PostTypeZoom from './post_type_zoom.jsx';
 function mapStateToProps(state, ownProps) {
     return {
         ...ownProps,
-        creatorName: ownProps.post.props.meeting_creator_username || "Someone",
+        creatorName: ownProps.post.props.meeting_creator_username || 'Someone',
         useMilitaryTime: getBool(state, 'display_settings', 'use_military_time', false),
         currentChannelId: getCurrentChannelId(state),
     };


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Old zoom messages do not have the property "meeting_creator_username", and therefore show "undefined has started a meeting".
![image](https://user-images.githubusercontent.com/1933730/74828926-40cd4d00-5310-11ea-9336-60bc73bd7e7e.png)
Also, the race condition confirmation also is lacking the "meeting_creator_username" property, so this PR adds that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22638

Fixes https://github.com/mattermost/mattermost-plugin-zoom/issues/76