### PR TITLE
Use user ID instead of bot ID to post meetings

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -76,7 +76,7 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 		}
 		meetingID := ru.Pmi
 
-		_, appErr = p.postMeeting(user.Username, meetingID, args.ChannelId, "")
+		_, appErr = p.postMeeting(user, meetingID, args.ChannelId, "")
 		if appErr != nil {
 			return "Failed to post message. Please try again.", nil
 		}

--- a/server/http.go
+++ b/server/http.go
@@ -109,12 +109,12 @@ type startMeetingRequest struct {
 	MeetingID int    `json:"meeting_id"`
 }
 
-func (p *Plugin) postMeeting(creatorUsername string, meetingID int, channelID string, topic string) (*model.Post, *model.AppError) {
+func (p *Plugin) postMeeting(creator *model.User, meetingID int, channelID string, topic string) (*model.Post, *model.AppError) {
 
 	meetingURL := p.getMeetingURL(meetingID)
 
 	post := &model.Post{
-		UserId:    p.botUserID,
+		UserId:    creator.Id,
 		ChannelId: channelID,
 		Message:   fmt.Sprintf("Meeting started at %s.", meetingURL),
 		Type:      "custom_zoom",
@@ -124,7 +124,7 @@ func (p *Plugin) postMeeting(creatorUsername string, meetingID int, channelID st
 			"meeting_status":           zoom.WebhookStatusStarted,
 			"meeting_personal":         true,
 			"meeting_topic":            topic,
-			"meeting_creator_username": creatorUsername,
+			"meeting_creator_username": creator.Username,
 		},
 	}
 
@@ -179,7 +179,7 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 	}
 	meetingID := ru.Pmi
 
-	createdPost, appErr := p.postMeeting(user.Username, meetingID, req.ChannelID, req.Topic)
+	createdPost, appErr := p.postMeeting(user, meetingID, req.ChannelID, req.Topic)
 	if appErr != nil {
 		http.Error(w, appErr.Error(), appErr.StatusCode)
 		return

--- a/webapp/src/components/post_type_zoom/index.js
+++ b/webapp/src/components/post_type_zoom/index.js
@@ -14,6 +14,7 @@ import PostTypeZoom from './post_type_zoom.jsx';
 function mapStateToProps(state, ownProps) {
     return {
         ...ownProps,
+        fromBot: ownProps.post.props.from_bot,
         creatorName: ownProps.post.props.meeting_creator_username || 'Someone',
         useMilitaryTime: getBool(state, 'display_settings', 'use_military_time', false),
         currentChannelId: getCurrentChannelId(state),

--- a/webapp/src/components/post_type_zoom/post_type_zoom.jsx
+++ b/webapp/src/components/post_type_zoom/post_type_zoom.jsx
@@ -79,7 +79,7 @@ export default class PostTypeZoom extends React.PureComponent {
         let content;
         let subtitle;
         if (props.meeting_status === 'STARTED') {
-            preText = `I have started a meeting`;
+            preText = 'I have started a meeting';
             if (this.props.fromBot) {
                 preText = `${this.props.creatorName} has started a meeting`;
             }
@@ -127,7 +127,7 @@ export default class PostTypeZoom extends React.PureComponent {
                 );
             }
         } else if (props.meeting_status === 'ENDED') {
-            preText = `I have ended the meeting`;
+            preText = 'I have ended the meeting';
             if (this.props.fromBot) {
                 preText = `${this.props.creatorName} has ended the meeting`;
             }

--- a/webapp/src/components/post_type_zoom/post_type_zoom.jsx
+++ b/webapp/src/components/post_type_zoom/post_type_zoom.jsx
@@ -47,6 +47,11 @@ export default class PostTypeZoom extends React.PureComponent {
          */
         currentChannelId: PropTypes.string.isRequired,
 
+        /*
+         * Whether the post was sent from a bot. Used for backwards compatibility.
+         */
+        fromBot: PropTypes.bool.isRequired,
+
         actions: PropTypes.shape({
             startMeeting: PropTypes.func.isRequired,
         }).isRequired,
@@ -74,7 +79,10 @@ export default class PostTypeZoom extends React.PureComponent {
         let content;
         let subtitle;
         if (props.meeting_status === 'STARTED') {
-            preText = `${this.props.creatorName} has started a meeting`;
+            preText = `I have started a meeting`;
+            if (this.props.fromBot) {
+                preText = `${this.props.creatorName} has started a meeting`;
+            }
             content = (
                 <a
                     className='btn btn-lg btn-primary'
@@ -119,7 +127,10 @@ export default class PostTypeZoom extends React.PureComponent {
                 );
             }
         } else if (props.meeting_status === 'ENDED') {
-            preText = `${this.props.creatorName} has ended the meeting`;
+            preText = `I have ended the meeting`;
+            if (this.props.fromBot) {
+                preText = `${this.props.creatorName} has ended the meeting`;
+            }
 
             if (props.meeting_personal) {
                 subtitle = 'Personal Meeting ID (PMI) : ' + props.meeting_id;


### PR DESCRIPTION
#### Summary
Meeting messages do not trigger notifications on direct channels due to them being posted by a bot, and not by any of the two users in the channel. Also, since they are posted by a bot, the user that created the meeting cannot delete the post.

This PR solves both problems by posting the messages in the name of the user, instead of posting them as the bot.

#### Current look
![Screenshot from 2020-05-13 12-48-10](https://user-images.githubusercontent.com/1933730/81805869-eb25cc80-951b-11ea-8019-ff865f158c02.png)

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/MM-23173
Fix https://mattermost.atlassian.net/browse/MM-19931

