### PR TITLE
Adding slack attachment on messages without plugin (and mobile)

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -269,6 +269,9 @@ type startMeetingRequest struct {
 func (p *Plugin) postMeeting(creator *model.User, meetingID int, channelID string, topic string) (*model.Post, *model.AppError) {
 
 	meetingURL := p.getMeetingURL(meetingID)
+	if topic == "" {
+		topic = "Zoom meeting"
+	}
 
 	slackAttachment := model.SlackAttachment{
 		Fallback:  fmt.Sprintf("Video Meeting started at [%d](%s).\n\n[Join Meeting](%s)", meetingID, meetingURL, meetingURL),

--- a/server/http.go
+++ b/server/http.go
@@ -246,12 +246,19 @@ func (p *Plugin) handleMeetingEnded(w http.ResponseWriter, r *http.Request, webh
 		topic = "Zoom Meeting"
 	}
 
+	meetingId, ok := post.Props["meeting_id"].(int)
+	var meetingIdStr string
+	if !ok {
+		meetingIdStr = "unknown"
+	}
+	meetingIdStr = fmt.Sprintf("%d", meetingId)
+
 	slackAttachment := model.SlackAttachment{
 		Fallback: fmt.Sprintf("Meeting %s has ended: started at %s, lenght: %d minute(s).", post.Props["meeting_id"], startText, length),
 		Title:    topic,
 		Text: fmt.Sprintf(
-			"Personal Meeting ID (PMI) : %d\n\n##### Meeting Summary\n\nDate: %s\n\nMeeting Length: %d minute(s)",
-			post.Props["meeting_id"],
+			"Personal Meeting ID (PMI) : %s\n\n##### Meeting Summary\n\nDate: %s\n\nMeeting Length: %d minute(s)",
+			meetingIdStr,
 			startText,
 			length,
 		),

--- a/server/http.go
+++ b/server/http.go
@@ -270,12 +270,19 @@ func (p *Plugin) postMeeting(creator *model.User, meetingID int, channelID strin
 
 	meetingURL := p.getMeetingURL(meetingID)
 
+	slackAttachment := model.SlackAttachment{
+		Fallback:  fmt.Sprintf("Video Meeting started at [%d](%s).\n\n[Join Meeting](%s)", meetingID, meetingURL, meetingURL),
+		Title:     topic,
+		TitleLink: meetingURL,
+		Text:      fmt.Sprintf("Personal Meeting ID (PMI) : [%d](%s)\n\n[:movie_camera:  Join Meeting](%s)", meetingID, meetingURL, meetingURL),
+	}
+
 	post := &model.Post{
 		UserId:    creator.Id,
 		ChannelId: channelID,
-		Message:   fmt.Sprintf("Meeting started at %s.", meetingURL),
 		Type:      "custom_zoom",
 		Props: map[string]interface{}{
+			"attachments":              []*model.SlackAttachment{&slackAttachment},
 			"meeting_id":               meetingID,
 			"meeting_link":             meetingURL,
 			"meeting_status":           zoom.WebhookStatusStarted,

--- a/server/http.go
+++ b/server/http.go
@@ -274,10 +274,9 @@ func (p *Plugin) postMeeting(creator *model.User, meetingID int, channelID strin
 	}
 
 	slackAttachment := model.SlackAttachment{
-		Fallback:  fmt.Sprintf("Video Meeting started at [%d](%s).\n\n[Join Meeting](%s)", meetingID, meetingURL, meetingURL),
-		Title:     topic,
-		TitleLink: meetingURL,
-		Text:      fmt.Sprintf("Personal Meeting ID (PMI) : [%d](%s)\n\n[:movie_camera:  Join Meeting](%s)", meetingID, meetingURL, meetingURL),
+		Fallback: fmt.Sprintf("Video Meeting started at [%d](%s).\n\n[Join Meeting](%s)", meetingID, meetingURL, meetingURL),
+		Title:    topic,
+		Text:     fmt.Sprintf("Personal Meeting ID (PMI) : [%d](%s)\n\n[:movie_camera:  Join Meeting](%s)", meetingID, meetingURL, meetingURL),
 	}
 
 	post := &model.Post{

--- a/server/http.go
+++ b/server/http.go
@@ -246,19 +246,14 @@ func (p *Plugin) handleMeetingEnded(w http.ResponseWriter, r *http.Request, webh
 		topic = "Zoom Meeting"
 	}
 
-	meetingId, ok := post.Props["meeting_id"].(int)
-	var meetingIdStr string
-	if !ok {
-		meetingIdStr = "unknown"
-	}
-	meetingIdStr = fmt.Sprintf("%d", meetingId)
+	meetingId := int(post.Props["meeting_id"].(float64))
 
 	slackAttachment := model.SlackAttachment{
 		Fallback: fmt.Sprintf("Meeting %s has ended: started at %s, lenght: %d minute(s).", post.Props["meeting_id"], startText, length),
 		Title:    topic,
 		Text: fmt.Sprintf(
-			"Personal Meeting ID (PMI) : %s\n\n##### Meeting Summary\n\nDate: %s\n\nMeeting Length: %d minute(s)",
-			meetingIdStr,
+			"Personal Meeting ID (PMI) : %d\n\n##### Meeting Summary\n\nDate: %s\n\nMeeting Length: %d minute(s)",
+			meetingId,
 			startText,
 			length,
 		),

--- a/server/http.go
+++ b/server/http.go
@@ -270,7 +270,7 @@ func (p *Plugin) postMeeting(creator *model.User, meetingID int, channelID strin
 
 	meetingURL := p.getMeetingURL(meetingID)
 	if topic == "" {
-		topic = "Zoom meeting"
+		topic = "Zoom Meeting"
 	}
 
 	slackAttachment := model.SlackAttachment{

--- a/server/http.go
+++ b/server/http.go
@@ -247,14 +247,17 @@ func (p *Plugin) handleMeetingEnded(w http.ResponseWriter, r *http.Request, webh
 		topic = "Zoom Meeting"
 	}
 
-	meetingId := int(post.Props["meeting_id"].(float64))
+	meetingId, ok := post.Props["meeting_id"].(float64)
+	if !ok {
+		meetingId = 0
+	}
 
 	slackAttachment := model.SlackAttachment{
 		Fallback: fmt.Sprintf("Meeting %s has ended: started at %s, lenght: %d minute(s).", post.Props["meeting_id"], startText, length),
 		Title:    topic,
 		Text: fmt.Sprintf(
 			"Personal Meeting ID (PMI) : %d\n\n##### Meeting Summary\n\nDate: %s\n\nMeeting Length: %d minute(s)",
-			meetingId,
+			int(meetingId),
 			startText,
 			length,
 		),

--- a/server/http.go
+++ b/server/http.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -239,7 +240,7 @@ func (p *Plugin) handleMeetingEnded(w http.ResponseWriter, r *http.Request, webh
 	}
 
 	start := time.Unix(0, post.CreateAt*int64(time.Millisecond))
-	length := int(((model.GetMillis() - post.CreateAt) / 1000) / 60)
+	length := int(math.Ceil(float64((model.GetMillis()-post.CreateAt)/1000) / 60))
 	startText := start.Format("Mon Jan 2 15:04:05 -0700 MST 2006")
 	topic, ok := post.Props["meeting_topic"].(string)
 	if !ok {

--- a/server/http.go
+++ b/server/http.go
@@ -248,7 +248,7 @@ func (p *Plugin) handleMeetingEnded(w http.ResponseWriter, r *http.Request, webh
 		Text:     fmt.Sprintf("Date: %s\n\nMeeting Length: %d minute(s)", startText, length),
 	}
 
-	post.Message = "Meeting has ended."
+	post.Message = "I have ended the meeting."
 	post.Props["meeting_status"] = zoom.WebhookStatusEnded
 	post.Props["attachments"] = []*model.SlackAttachment{&slackAttachment}
 
@@ -293,7 +293,7 @@ func (p *Plugin) postMeeting(creator *model.User, meetingID int, channelID strin
 	post := &model.Post{
 		UserId:    creator.Id,
 		ChannelId: channelID,
-		Message:   fmt.Sprintf("%s has started a meeting", creator.Username),
+		Message:   "I have started a meeting",
 		Type:      "custom_zoom",
 		Props: map[string]interface{}{
 			"attachments":              []*model.SlackAttachment{&slackAttachment},


### PR DESCRIPTION
The message shown when you don't have the plugin or you are in mobile is way
worse than the one with the plugin. This change fill a bit the gap using an
slack attachment that is more similar to the custom post format.