### PR TITLE
 Store post ID when creating meeting via slash command, add some logging and set expiry time to meeting post IDs to avoid garbage in the KVStore

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -75,9 +75,14 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 
 		meetingID := zoomUser.Pmi
 
-		_, appErr = p.postMeeting(user, meetingID, args.ChannelId, "")
+		var createdPost *model.Post
+		createdPost, appErr = p.postMeeting(user, meetingID, args.ChannelId, "")
 		if appErr != nil {
 			return "Failed to post message. Please try again.", nil
+		}
+
+		if appErr = p.API.KVSetWithExpiry(fmt.Sprintf("%v%v", postMeetingKey, meetingID), []byte(createdPost.Id), meetingPostIDTTL); appErr != nil {
+			p.API.LogDebug("failed to store post id", "err", appErr)
 		}
 		return "", nil
 	case "disconnect":

--- a/server/command.go
+++ b/server/command.go
@@ -79,7 +79,6 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 		if err != nil {
 			return "Failed to post message. Please try again.", nil
 		}
-
 		return "", nil
 	case "disconnect":
 		if p.configuration.EnableLegacyAuth {

--- a/server/command.go
+++ b/server/command.go
@@ -75,15 +75,11 @@ func (p *Plugin) executeCommand(c *plugin.Context, args *model.CommandArgs) (str
 
 		meetingID := zoomUser.Pmi
 
-		var createdPost *model.Post
-		createdPost, appErr = p.postMeeting(user, meetingID, args.ChannelId, "")
-		if appErr != nil {
+		err := p.postMeeting(user, meetingID, args.ChannelId, "")
+		if err != nil {
 			return "Failed to post message. Please try again.", nil
 		}
 
-		if appErr = p.API.KVSetWithExpiry(fmt.Sprintf("%v%v", postMeetingKey, meetingID), []byte(createdPost.Id), meetingPostIDTTL); appErr != nil {
-			p.API.LogDebug("failed to store post id", "err", appErr)
-		}
 		return "", nil
 	case "disconnect":
 		if p.configuration.EnableLegacyAuth {

--- a/server/http.go
+++ b/server/http.go
@@ -152,7 +152,8 @@ func (p *Plugin) completeUserOAuthToZoom(w http.ResponseWriter, r *http.Request)
 		OAuthToken: tok,
 	}
 
-	if err := p.storeZoomUserInfo(zoomUserInfo); err != nil {
+	err = p.storeZoomUserInfo(zoomUserInfo)
+	if err != nil {
 		http.Error(w, "Unable to connect user to Zoom", http.StatusInternalServerError)
 		return
 	}

--- a/server/http.go
+++ b/server/http.go
@@ -159,10 +159,14 @@ func (p *Plugin) completeUserOAuthToZoom(w http.ResponseWriter, r *http.Request)
 
 	user, _ := p.API.GetUser(userID)
 
-	_, appErr = p.postMeeting(user, zoomUser.Pmi, channelID, "")
+	createdPost, appErr := p.postMeeting(user, zoomUser.Pmi, channelID, "")
 	if appErr != nil {
 		http.Error(w, appErr.Error(), appErr.StatusCode)
 		return
+	}
+
+	if appErr = p.API.KVSetWithExpiry(fmt.Sprintf("%v%v", postMeetingKey, zoomUser.Pmi), []byte(createdPost.Id), meetingPostIDTTL); appErr != nil {
+		p.API.LogDebug("failed to store post id", "err", appErr)
 	}
 
 	html := `

--- a/server/http.go
+++ b/server/http.go
@@ -420,6 +420,7 @@ func (p *Plugin) getMeetingURL(meetingID int, userID string) string {
 	if p.configuration.EnableLegacyAuth {
 		meeting, err := p.zoomClient.GetMeeting(meetingID)
 		if err == nil {
+			p.API.LogDebug("failed to get meeting", "error", err.Error())
 			return meeting.JoinURL
 		}
 	}
@@ -427,6 +428,7 @@ func (p *Plugin) getMeetingURL(meetingID int, userID string) string {
 	if p.configuration.EnableOAuth {
 		meeting, err := p.GetMeetingOAuth(meetingID, userID)
 		if err == nil {
+			p.API.LogDebug("failed to get meeting", "error", err.Error())
 			return meeting.JoinURL
 		}
 	}
@@ -441,7 +443,10 @@ func (p *Plugin) getMeetingURL(meetingID int, userID string) string {
 }
 
 func (p *Plugin) postConfirm(meetingID int, channelID string, topic string, userID string, creatorName string) *model.Post {
-	creator, _ := p.API.GetUserByUsername(creatorName)
+	creator, err := p.API.GetUserByUsername(creatorName)
+	if err != nil {
+		p.API.LogDebug("error fetching user on postConfirm", "error", err.Error())
+	}
 	creatorID := ""
 	if creator != nil {
 		creatorID = creator.Id

--- a/server/http.go
+++ b/server/http.go
@@ -420,17 +420,17 @@ func (p *Plugin) getMeetingURL(meetingID int, userID string) string {
 	if p.configuration.EnableLegacyAuth {
 		meeting, err := p.zoomClient.GetMeeting(meetingID)
 		if err == nil {
-			p.API.LogDebug("failed to get meeting", "error", err.Error())
 			return meeting.JoinURL
 		}
+		p.API.LogDebug("failed to get meeting", "error", err.Error())
 	}
 
 	if p.configuration.EnableOAuth {
 		meeting, err := p.GetMeetingOAuth(meetingID, userID)
 		if err == nil {
-			p.API.LogDebug("failed to get meeting", "error", err.Error())
 			return meeting.JoinURL
 		}
+		p.API.LogDebug("failed to get meeting", "error", err.Error())
 	}
 
 	config := p.getConfiguration()

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -319,7 +319,8 @@ func (p *Plugin) getZoomUserWithToken(token *oauth2.Token) (*zoom.User, error) {
 
 func (p *Plugin) GetMeetingOAuth(meetingID int, userID string) (*zoom.Meeting, error) {
 	config := p.getConfiguration()
-	ctx := context.Background()
+	ctx, cancelFunct := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancelFunct()
 
 	conf, err := p.getOAuthConfig()
 	if err != nil {
@@ -332,7 +333,6 @@ func (p *Plugin) GetMeetingOAuth(meetingID int, userID string) (*zoom.Meeting, e
 	}
 
 	client := conf.Client(ctx, zoomUserInfo.OAuthToken)
-	client.Timeout = 10 * time.Second
 	apiURL := config.ZoomAPIURL
 	if apiURL == "" {
 		apiURL = zoomDefaultAPIURL

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -327,7 +327,7 @@ func (p *Plugin) GetMeetingOAuth(meetingID int, userID string) (*zoom.Meeting, e
 
 	zoomUserInfo, apiErr := p.getZoomUserInfo(userID)
 	if apiErr != nil {
-		return nil, err
+		return nil, apiErr
 	}
 
 	client := conf.Client(ctx, zoomUserInfo.OAuthToken)
@@ -338,8 +338,11 @@ func (p *Plugin) GetMeetingOAuth(meetingID int, userID string) (*zoom.Meeting, e
 
 	url := fmt.Sprintf("%v/meetings/%v", apiURL, meetingID)
 	res, err := client.Get(url)
-	if err != nil || res == nil {
+	if err != nil {
 		return nil, errors.New("error fetching zoom user, err=" + err.Error())
+	}
+	if res == nil {
+		return nil, errors.New("error fetching zoom user, empty result returned")
 	}
 	defer res.Body.Close()
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -37,6 +37,8 @@ const (
 	zoomStateLength   = 3
 	zoomOAuthMessage  = "[Click here to link your Zoom account.](%s/plugins/zoom/oauth2/connect?channelID=%s)"
 	zoomEmailMismatch = "We could not verify your Mattermost account in Zoom. Please ensure that your Mattermost email address %s matches your Zoom login email address."
+
+	meetingPostIDTTL = 60 * 60 * 24 // One day
 )
 
 type Plugin struct {

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -103,6 +103,7 @@ func TestPlugin(t *testing.T) {
 			api.On("KVDelete", fmt.Sprintf("%v%v", postMeetingKey, 234)).Return(nil)
 
 			api.On("LogWarn", mock.AnythingOfType("string")).Return()
+			api.On("LogDebug", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return()
 
 			path, err := filepath.Abs("..")
 			require.Nil(t, err)

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -94,13 +94,15 @@ func TestPlugin(t *testing.T) {
 			api.On("UpdatePost", mock.AnythingOfType("*model.Post")).Return(&model.Post{}, nil)
 			api.On("GetPostsSince", "thechannelid", mock.AnythingOfType("int64")).Return(&model.PostList{}, nil)
 
-			api.On("KVSet", fmt.Sprintf("%v%v", postMeetingKey, 234), mock.AnythingOfType("[]uint8")).Return(nil)
-			api.On("KVSet", fmt.Sprintf("%v%v", postMeetingKey, 123), mock.AnythingOfType("[]uint8")).Return(nil)
+			api.On("KVSetWithExpiry", fmt.Sprintf("%v%v", postMeetingKey, 234), mock.AnythingOfType("[]uint8"), mock.AnythingOfType("int64")).Return(nil)
+			api.On("KVSetWithExpiry", fmt.Sprintf("%v%v", postMeetingKey, 123), mock.AnythingOfType("[]uint8"), mock.AnythingOfType("int64")).Return(nil)
 
 			api.On("KVGet", fmt.Sprintf("%v%v", postMeetingKey, 234)).Return([]byte("thepostid"), nil)
 			api.On("KVGet", fmt.Sprintf("%v%v", postMeetingKey, 123)).Return([]byte("thepostid"), nil)
 
 			api.On("KVDelete", fmt.Sprintf("%v%v", postMeetingKey, 234)).Return(nil)
+
+			api.On("LogWarn", mock.AnythingOfType("string")).Return()
 
 			path, err := filepath.Abs("..")
 			require.Nil(t, err)

--- a/webapp/.npmrc
+++ b/webapp/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
#### Summary
In order to allow the meeting ended webhook, we have to store the meeting Post ID in the KVStore to modify it after the call. This was not done when creating a meeting via slash command.

I also added the expiry time to the post IDs so they do not create garbage if the webhook never arrives (for example because the meeting never started).

#### Ticket Link
Fix #128 

