### PR TITLE
[GH-137] Fix "If user's email is not valid for JWT Zoom, launching Zoom from the icon will show oAuth link "

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -378,7 +378,7 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			p.API.LogWarn("failed to write response", "error", err.Error())
 		}
-		p.postConnect(req.ChannelID, userID)
+		p.postAuthenticationMessage(req.ChannelID, userID, authErr.Message)
 		return
 	}
 
@@ -440,15 +440,11 @@ func (p *Plugin) postConfirm(meetingID int, channelID string, topic string, user
 	return p.API.SendEphemeralPost(userID, post)
 }
 
-func (p *Plugin) postConnect(channelID string, userID string) *model.Post {
-	oauthMsg := fmt.Sprintf(
-		zoomOAuthMessage,
-		*p.API.GetConfig().ServiceSettings.SiteURL, channelID)
-
+func (p *Plugin) postAuthenticationMessage(channelID string, userID string, message string) *model.Post {
 	post := &model.Post{
 		UserId:    p.botUserID,
 		ChannelId: channelID,
-		Message:   oauthMsg,
+		Message:   message,
 	}
 
 	return p.API.SendEphemeralPost(userID, post)


### PR DESCRIPTION
#### Summary
Post the already created authmessage on failed connection when using the header icon

#### Ticket Link
Fix #137 

