### PR TITLE
solves GH 178 - Add friendly message on disconnect if user is not currently authenticated

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -181,7 +181,7 @@ func (p *Plugin) runDisconnectCommand(user *model.User) (string, error) {
 	}
 
 	if err := p.disconnectOAuthUser(user.Id); err != nil {
-		return fmt.Sprintf("Failed to disconnect the user: %s", err.Error()), nil
+		return "Your Zoom account is not currently linked.", nil
 	}
 
 	p.trackDisconnect(user.Id)

--- a/server/command.go
+++ b/server/command.go
@@ -175,13 +175,15 @@ func (p *Plugin) runDisconnectCommand(user *model.User) (string, error) {
 	if p.configuration.AccountLevelApp {
 		err := p.removeSuperUserToken()
 		if err != nil {
-			return "Could not disconnect, err=" + err.Error(), nil
+			return "Error disconnecting, " + err.Error(), nil
 		}
 		return "Successfully disconnected from Zoom.", nil
 	}
 
-	if err := p.disconnectOAuthUser(user.Id); err != nil {
-		return "Your Zoom account is not currently linked.", nil
+	err := p.disconnectOAuthUser(user.Id)
+
+	if err != nil {
+		return "Could not disconnect OAuth from zoom, " + err.Error(), nil
 	}
 
 	p.trackDisconnect(user.Id)

--- a/server/store.go
+++ b/server/store.go
@@ -65,7 +65,13 @@ func (p *Plugin) fetchOAuthUserInfo(tokenKey, userID string) (*zoom.OAuthUserInf
 }
 
 func (p *Plugin) disconnectOAuthUser(userID string) error {
+	// according to the definition encoded would be nil
+	// that means that the account is not linked
 	encoded, err := p.API.KVGet(zoomUserByMMID + userID)
+	if len(encoded) == 0 {
+		return errors.Wrap(err, "Your Zoom account is not currently linked")
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "could not find OAuth user info")
 	}

--- a/server/store.go
+++ b/server/store.go
@@ -72,7 +72,7 @@ func (p *Plugin) disconnectOAuthUser(userID string) error {
 		return errors.Wrap(err, "could not find OAuth user info")
 	}
 	if encoded == nil {
-		return errors.New("You are not connected to Zoom yet")
+		return errors.New("you are not connected to Zoom yet")
 	}
 
 	var info zoom.OAuthUserInfo

--- a/server/store.go
+++ b/server/store.go
@@ -66,14 +66,13 @@ func (p *Plugin) fetchOAuthUserInfo(tokenKey, userID string) (*zoom.OAuthUserInf
 
 func (p *Plugin) disconnectOAuthUser(userID string) error {
 	// according to the definition encoded would be nil
-	// that means that the account is not linked
 	encoded, err := p.API.KVGet(zoomUserByMMID + userID)
-	if len(encoded) == 0 {
-		return errors.Wrap(err, "Your Zoom account is not currently linked")
-	}
 
 	if err != nil {
 		return errors.Wrap(err, "could not find OAuth user info")
+	}
+	if encoded == nil {
+		return errors.New("You are not connected to Zoom yet")
 	}
 
 	var info zoom.OAuthUserInfo


### PR DESCRIPTION
#### Summary
Add friendly message on disconnect if user is not currently authenticated
#### Ticket Link
https://github.com/mattermost/mattermost-plugin-zoom/issues/178
