### PR TITLE
Remove scopes from OAuth calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ webapp/dist
 # Mac
 *.swp
 .DS_Store
+
+#IDEs
+/.idea
+/.vscode

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -180,10 +180,6 @@ func (p *Plugin) getOAuthConfig() *oauth2.Config {
 	config := p.getConfiguration()
 	zoomURL := p.getZoomURL()
 
-	adminString := ""
-	if p.configuration.AccountLevelApp {
-		adminString = ":admin"
-	}
 	return &oauth2.Config{
 		ClientID:     config.OAuthClientID,
 		ClientSecret: config.OAuthClientSecret,
@@ -192,12 +188,6 @@ func (p *Plugin) getOAuthConfig() *oauth2.Config {
 			TokenURL: fmt.Sprintf("%v/oauth/token", zoomURL),
 		},
 		RedirectURL: fmt.Sprintf("%s/plugins/zoom/oauth2/complete", p.siteURL),
-		Scopes: []string{
-			"user:read" + adminString,
-			"meeting:write" + adminString,
-			"webinar:write" + adminString,
-			"recording:write" + adminString,
-		},
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Apparently due to recent changes in how Zoom handles OAuth applications it no longer accepts specifying scopes with OAuth calls. According to Zoom, scopes passed in URLs were never used but now are no longer accepted.
Here's forum discussion around the topic: https://devforum.zoom.us/t/invalid-scope-errors/52654

From Zoom's employee response:
> "While Zoom never explicitly supported including app scopes as part of the authorization URL, this was previously ignored in the case that they were included. However, as part of our ongoing commitment of prioritizing security, a recent enhancement was made that will now consider scopes added directly to the authorization URL to be considered invalid. You will need to omit the scope parameter from your URL and let your OAuth Marketplace App handle the scopes for your integration."


The issue happens only when authorizing new applications with `zoom connect`. Connecting to an already authorized application works without problems.

As mentioned in the forum post removing scopes from calls fixes the issue.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

