### PR TITLE
Revert "[GH-235] Refresh token on user level oauth (#235) (#242)"

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -240,31 +240,3 @@ func (p *Plugin) SetZoomSuperUserToken(token *oauth2.Token) error {
 	}
 	return nil
 }
-
-func (p *Plugin) GetZoomUserToken(userID string) (*oauth2.Token, error) {
-	token, err := p.fetchOAuthUserInfo(zoomUserByZoomID, userID)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get token")
-	}
-	if token == nil {
-		return nil, errors.New("zoom app not connected")
-	}
-	return token.OAuthToken, nil
-}
-
-func (p *Plugin) UpdateZoomUserToken(userID string, token *oauth2.Token) error {
-	zoomUser, err := p.fetchOAuthUserInfo(zoomUserByZoomID, userID)
-	if err != nil {
-		p.API.LogError("could not update zoom user token", err)
-		return errors.Wrap(err, "could not update zoom user token")
-	}
-
-	zoomUser.OAuthToken = token
-	if err = p.storeOAuthUserInfo(zoomUser); err != nil {
-		msg := "unable to update user token"
-		p.API.LogWarn(msg, "error", err.Error())
-		return errors.Wrap(err, msg)
-	}
-
-	return nil
-}

--- a/server/zoom/client.go
+++ b/server/zoom/client.go
@@ -34,6 +34,4 @@ type Client interface {
 type PluginAPI interface {
 	GetZoomSuperUserToken() (*oauth2.Token, error)
 	SetZoomSuperUserToken(*oauth2.Token) error
-	GetZoomUserToken(userID string) (*oauth2.Token, error)
-	UpdateZoomUserToken(userID string, token *oauth2.Token) error
 }

--- a/server/zoom/oauth.go
+++ b/server/zoom/oauth.go
@@ -150,26 +150,6 @@ func (c *OAuthClient) getUserViaOAuth(user *model.User) (*User, error) {
 		}
 
 		c.token = updatedToken
-	} else {
-		currentToken, err := c.api.GetZoomUserToken(user.Id)
-		if err != nil {
-			return nil, errors.Wrap(err, "error getting zoom user token")
-		}
-
-		tokenSource := c.config.TokenSource(context.Background(), currentToken)
-		updatedToken, err := tokenSource.Token()
-		if err != nil {
-			return nil, errors.Wrap(err, "error getting token from token source")
-		}
-
-		if updatedToken.AccessToken != currentToken.AccessToken {
-			kvErr := c.api.UpdateZoomUserToken(user.Id, updatedToken)
-			if kvErr != nil {
-				return nil, errors.Wrap(kvErr, "error setting new token")
-			}
-		}
-
-		c.token = updatedToken
 	}
 
 	client := c.config.Client(context.Background(), c.token)


### PR DESCRIPTION
This reverts commit 8a5a54dcb4b1970d8c70a618eaa983a29c9c8402.

This PR reverts https://github.com/mattermost/mattermost-plugin-zoom/pull/242, which introduced some issues with OAuth token management, including an error with coordinating encryption/decryption, resulting in corrupted tokens.

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

