### PR TITLE
[MM-51269] Log errors from telemetry events

### DIFF
--- a/server/telemetry.go
+++ b/server/telemetry.go
@@ -9,30 +9,44 @@ const (
 	telemetryStartSourceCommand = "command"
 )
 
+func (p *Plugin) TrackEvent(event string, properties map[string]interface{}) {
+	err := p.tracker.TrackEvent(event, properties)
+	if err != nil {
+		p.API.LogDebug("Error sending telemetry event", "event", event, "error", err.Error())
+	}
+}
+
+func (p *Plugin) TrackUserEvent(event, userID string, properties map[string]interface{}) {
+	err := p.tracker.TrackUserEvent(event, userID, properties)
+	if err != nil {
+		p.API.LogDebug("Error sending user telemetry event", "event", event, "error", err.Error())
+	}
+}
+
 func (p *Plugin) trackConnect(userID string) {
-	_ = p.tracker.TrackUserEvent("connect", userID, map[string]interface{}{})
+	p.TrackUserEvent("connect", userID, map[string]interface{}{})
 }
 
 func (p *Plugin) trackDisconnect(userID string) {
-	_ = p.tracker.TrackUserEvent("disconnect", userID, map[string]interface{}{})
+	p.TrackUserEvent("disconnect", userID, map[string]interface{}{})
 }
 
 func (p *Plugin) trackOAuthModeChange(method string) {
-	_ = p.tracker.TrackEvent("oauth_mode_change", map[string]interface{}{
+	p.TrackEvent("oauth_mode_change", map[string]interface{}{
 		"method": method,
 	})
 }
 
 func (p *Plugin) trackMeetingStart(userID, source string) {
-	_ = p.tracker.TrackUserEvent("start_meeting", userID, map[string]interface{}{
+	p.TrackUserEvent("start_meeting", userID, map[string]interface{}{
 		"source": source,
 	})
 }
 
 func (p *Plugin) trackMeetingDuplication(userID string) {
-	_ = p.tracker.TrackUserEvent("meeting_duplicated", userID, map[string]interface{}{})
+	p.TrackUserEvent("meeting_duplicated", userID, map[string]interface{}{})
 }
 
 func (p *Plugin) trackMeetingForced(userID string) {
-	_ = p.tracker.TrackUserEvent("meeting_forced", userID, map[string]interface{}{})
+	p.TrackUserEvent("meeting_forced", userID, map[string]interface{}{})
 }


### PR DESCRIPTION
#### Summary
Previously errors returned from the telemetry tracker didn't get logged. This PR adds proper log messages for all errors the telemetry tracker returns.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51269