### PR TITLE
fix rudder key secret name

### DIFF
--- a/build/custom.mk
+++ b/build/custom.mk
@@ -1,6 +1,8 @@
 # Include custome targets and environment variables here
-ifndef MM_RUDDER_WRITE_KEY
-    MM_RUDDER_WRITE_KEY = 1d5bMvdrfWClLxgK1FvV3s4U1tg
-endif
 
-GO_BUILD_FLAGS += -ldflags '-X "github.com/mattermost/mattermost-plugin-api/experimental/telemetry.rudderWriteKey=$(MM_RUDDER_WRITE_KEY)"'
+# If there's no MM_RUDDER_PLUGINS_PROD, add DEV data
+RUDDER_WRITE_KEY = 1d5bMvdrfWClLxgK1FvV3s4U1tg
+ifdef MM_RUDDER_PLUGINS_PROD
+  RUDDER_WRITE_KEY = $(MM_RUDDER_PLUGINS_PROD)
+endif
+GO_BUILD_FLAGS += -ldflags '-X "github.com/mattermost/mattermost-plugin-api/experimental/telemetry.rudderWriteKey=$(RUDDER_WRITE_KEY)"'


### PR DESCRIPTION
#### Summary
After some name changing, MM_RUDDER_WRITE_KEY has become MM_RUDDER_PLUGINS_PROD.

Fix custom.mk so we get the right data.

#### Ticket Link
nope

