### PR TITLE
[GH-313] Redirect user when a new meeting is started

### DIFF
--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -21,8 +21,7 @@ export default class Client {
             meeting_id: meetingId,
         });
 
-        const data = await res.json();
-        return data.meeting_url;
+        return res.meeting_url;
     }
 
     forceStartMeeting = async (channelId, rootId, personal = true, topic = '', meetingId = 0) => {
@@ -45,7 +44,7 @@ export const doPost = async (url, body, headers = {}) => {
 
     const response = await fetch(url, Client4.getOptions(options));
     if (response.ok) {
-        return response;
+        return response.json();
     }
 
     const text = await response.text();

--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -20,7 +20,9 @@ export default class Client {
             topic,
             meeting_id: meetingId,
         });
-        return res.meeting_url;
+
+        const data = await res.json();
+        return data.meeting_url;
     }
 
     forceStartMeeting = async (channelId, rootId, personal = true, topic = '', meetingId = 0) => {


### PR DESCRIPTION
#### Summary
- When a new meeting is started using the Zoom icon in the app bar/channel header the user is not getting redirected to the meeting tab because the meeting URL is undefined.
- We updated the logic to convert the response of the start meeting API to JSON for fetching the meeting URL.

#### What to test?
- When a user starts a new meeting using the Zoom icon in the app bar/channel header, he/she should be redirected to the meeting page.

###### Steps to reproduce:
- Click on the Zoom icon in the app bar/channel header. (Note: These should not be an existing meeting of the user in that channel)

###### Environment:
MM version: v7.8.10
Node version: 14.18.0
Go version: 1.19.0

#### Ticket Link

Fixes #313 

