### PR TITLE
[GH-312] Removed the unnecessary hint in "settings" command.

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -294,7 +294,7 @@ func (p *Plugin) getAutocompleteData() *model.AutocompleteData {
 	}
 
 	// setting to allow the user to decide whether to use PMI for instant meetings
-	setting := model.NewAutocompleteData("settings", "[command]", "Update your preferences")
+	setting := model.NewAutocompleteData("settings", "", "Update your preferences")
 	zoom.AddCommand(setting)
 
 	help := model.NewAutocompleteData("help", "", "Display usage")


### PR DESCRIPTION
#### Summary
Removed the unnecessary hint in "settings" command.

#### Screenshots:
Earlier:
![Image](https://github.com/mattermost/mattermost-plugin-zoom/assets/55234496/acfbb73d-f7a7-4e9a-a1af-f60947f2eef2)

Now:
![Image](https://github.com/mattermost/mattermost-plugin-zoom/assets/55234496/b6d41c16-c2c3-4f8f-a241-f54bc5596407)

#### What to test?
- "[command]" should not be visible in the "settings" slash command suggestion.

###### Steps to reproduce:
- Type the command `/zoom settings`.

###### Environment:
MM version: v7.8.10
Node version: 14.18.0
Go version: 1.19.0

#### Ticket Link

Fixes #312 

