### PR TITLE
Replaced legacy GitBook URLs with PL link

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -22,7 +22,7 @@
         "bundle_path": "webapp/dist/main.js"
     },
     "settings_schema": {
-        "header": "To set up this plugin you first need to create a Zoom App using a Zoom Administrator account. Visit the [documentation for configuration steps](https://github.com/mattermost/mattermost-plugin-zoom#admin-guide).",
+        "header": "To set up this plugin you first need to create a Zoom App using a Zoom Administrator account. Visit the [documentation for configuration steps](https://mattermost.com/pl/mattermost-plugin-zoom).",
         "footer": "",
         "settings": [
             {


### PR DESCRIPTION
Replaced absolute GitHub link with permalink [via Marketing](https://docs.google.com/spreadsheets/d/1O601H_A0IM8pR3FOfue29_C8flGV7xK3ts-tJUVDHHg/edit#gid=0).

Addresses: https://mattermost.atlassian.net/browse/MM-55436