### PR TITLE
[MI-3770] Fixed getting improper response in channel when user's account is disconnected

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -484,6 +484,21 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	zoomUser, authErr := p.authenticateAndFetchZoomUser(user)
+	if authErr != nil {
+		if _, err := w.Write([]byte(`{"meeting_url": ""}`)); err != nil {
+			p.API.LogWarn("failed to write the response", "error", err.Error())
+		}
+
+		// the user state will be needed later while connecting the user to Zoom via OAuth
+		if appErr := p.storeOAuthUserState(userID, req.ChannelID, false); appErr != nil {
+			p.API.LogWarn("failed to store user state")
+		}
+
+		p.postAuthenticationMessage(req.ChannelID, userID, authErr.Message)
+		return
+	}
+
 	if r.URL.Query().Get("force") == "" {
 		recentMeeting, recentMeetingLink, creatorName, provider, cpmErr := p.checkPreviousMessages(req.ChannelID)
 		if cpmErr != nil {
@@ -498,21 +513,6 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 			p.postConfirm(recentMeetingLink, req.ChannelID, req.Topic, userID, req.RootID, creatorName, provider)
 			return
 		}
-	}
-
-	zoomUser, authErr := p.authenticateAndFetchZoomUser(user)
-	if authErr != nil {
-		if _, err := w.Write([]byte(`{"meeting_url": ""}`)); err != nil {
-			p.API.LogWarn("failed to write the response", "error", err.Error())
-		}
-
-		// the user state will be needed later while connecting the user to Zoom via OAuth
-		if appErr := p.storeOAuthUserState(userID, req.ChannelID, false); appErr != nil {
-			p.API.LogWarn("failed to store user state")
-		}
-
-		p.postAuthenticationMessage(req.ChannelID, userID, authErr.Message)
-		return
 	}
 
 	topic := req.Topic


### PR DESCRIPTION
#### Summary
When a user tries to create a meeting after disconnecting their account, they get a meeting link in case they have created a meeting recently.

#### Screenshot:
![image](https://github.com/mattermost/mattermost-plugin-zoom/assets/55234496/e7584096-9c39-4370-8afd-1830490636b6)

#### What to test?
- The user is getting a connection link if they try to create a meeting after he/she has disconnected their account.

###### Steps to reproduce:
1. run /zoom connect and connect your account.
2. run /zoom start OR click the Zoom button in the app bar.
3. run /zoom disconnect.
4. run /zoom start OR click the Zoom button in the app bar.

Note: The last two steps must be done within 30 seconds after the second step.

###### Expected Behaviour:
The user is getting a link to connect his account.

###### Environment:
MM version: v9.2.2
Node version: 14.18.0
Go version: 1.20.11

#### Ticket Link
Fixes #306 

