### PR TITLE
Test PR: Image link path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Mattermost Zoom integration allows team members to initiate a Zoom meeting w
 
 **Important**: Only Zoom users associated with the Zoom Account that created the Zoom App will be able to use the plugin. You can add these users from the **Manage Users** section in the Zoom Account settings.
 
-![image](https://github.com/mattermost/mattermost-plugin-zoom/blob/master/assets/example.png)
+![image](./assets/example.png)
 
 ## Admin guide
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Mattermost Zoom integration allows team members to initiate a Zoom meeting w
 
 **Important**: Only Zoom users associated with the Zoom Account that created the Zoom App will be able to use the plugin. You can add these users from the **Manage Users** section in the Zoom Account settings.
 
-![image](https://github.com/mattermost/mattermost-plugin-zoom/assets/55234496/a109df21-f3c4-4432-b42d-7ef3ae493a50)
+![image](https://github.com/mattermost/mattermost-plugin-zoom/blob/master/assets/example.png)
 
 ## Admin guide
 


### PR DESCRIPTION
Updated the first image on the README page to be an absolute link rather than a hashed image. Looking to verify whether GitHub converts the path to a hashed image post-commit.
