### PR TITLE
[MM-154] Updated the default setting for meeting ID

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -159,10 +159,10 @@ func (p *Plugin) runStartCommand(args *model.CommandArgs, user *model.User, topi
 
 	createMeetingWithPMI := false
 	switch userPMISettingPref {
-	case zoomPMISettingValueAsk:
+	case "", zoomPMISettingValueAsk:
 		p.askPreferenceForMeeting(user.Id, args.ChannelId, args.RootId)
 		return "", nil
-	case "", trueString:
+	case trueString:
 		createMeetingWithPMI = true
 		meetingID = zoomUser.Pmi
 
@@ -303,7 +303,7 @@ func (p *Plugin) getAutocompleteData() *model.AutocompleteData {
 	}
 
 	// setting to allow the user to decide whether to use PMI for instant meetings
-	setting := model.NewAutocompleteData("settings", "", "Update your preferences")
+	setting := model.NewAutocompleteData("settings", "", "Update your meeting ID preferences")
 	zoom.AddCommand(setting)
 
 	help := model.NewAutocompleteData("help", "", "Display usage")

--- a/server/http.go
+++ b/server/http.go
@@ -21,27 +21,28 @@ import (
 )
 
 const (
-	defaultMeetingTopic      = "Zoom Meeting"
-	zoomOAuthUserStateLength = 4
-	settingDataError         = "something went wrong while getting settings data"
-	askForPMIMeeting         = "Would you like to use your personal meeting ID?"
-	pathWebhook              = "/webhook"
-	pathStartMeeting         = "/api/v1/meetings"
-	pathConnectUser          = "/oauth2/connect"
-	pathCompleteUserOAuth    = "/oauth2/complete"
-	pathDeauthorizeUser      = "/deauthorization"
-	pathUpdatePMI            = "/api/v1/updatePMI"
-	pathAskPMI               = "/api/v1/askPMI"
-	yes                      = "Yes"
-	no                       = "No"
-	ask                      = "Ask"
-	actionForContext         = "action"
-	userIDForContext         = "userID"
-	channelIDForContext      = "channelID"
-	rootIDForContext         = "rootID"
-	usePersonalMeetingID     = "USE PERSONAL MEETING ID"
-	useAUniqueMeetingID      = "USE A UNIQUE MEETING ID"
-	MattermostUserIDHeader   = "Mattermost-User-ID"
+	defaultMeetingTopic        = "Zoom Meeting"
+	zoomOAuthUserStateLength   = 4
+	settingDataError           = "something went wrong while getting settings data"
+	zoomSettingsCommandMessage = "You can set a default value for this in your user settings via `/zoom settings` command."
+	askForMeetingType          = "Which meeting ID would you like to use for creating this meeting?"
+	pathWebhook                = "/webhook"
+	pathStartMeeting           = "/api/v1/meetings"
+	pathConnectUser            = "/oauth2/connect"
+	pathCompleteUserOAuth      = "/oauth2/complete"
+	pathDeauthorizeUser        = "/deauthorization"
+	pathUpdatePMI              = "/api/v1/updatePMI"
+	pathAskPMI                 = "/api/v1/askPMI"
+	yes                        = "Yes"
+	no                         = "No"
+	ask                        = "Ask"
+	actionForContext           = "action"
+	userIDForContext           = "userID"
+	channelIDForContext        = "channelID"
+	rootIDForContext           = "rootID"
+	usePersonalMeetingID       = "Use Personal Meeting ID"
+	useAUniqueMeetingID        = "Use a Unique Meeting ID"
+	MattermostUserIDHeader     = "Mattermost-User-ID"
 )
 
 type startMeetingRequest struct {
@@ -416,7 +417,8 @@ func (p *Plugin) askPreferenceForMeeting(userID, channelID, rootID string) {
 	apiEndPoint := fmt.Sprintf("/plugins/%s%s", manifest.ID, pathAskPMI)
 
 	slackAttachment := model.SlackAttachment{
-		Pretext: askForPMIMeeting,
+		Pretext: zoomSettingsCommandMessage,
+		Title:   askForMeetingType,
 		Actions: []*model.PostAction{
 			{
 				Id:    "WithPMI",
@@ -545,14 +547,14 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 
 	createMeetingWithPMI := false
 	switch userPMISettingPref {
-	case zoomPMISettingValueAsk:
+	case "", zoomPMISettingValueAsk:
 		p.askPreferenceForMeeting(user.Id, req.ChannelID, req.RootID)
 
 		if _, err = w.Write([]byte(`{"meeting_url": ""}`)); err != nil {
 			p.API.LogWarn("failed to write the response", "Error", err.Error())
 		}
 		return
-	case "", trueString:
+	case trueString:
 		createMeetingWithPMI = true
 		meetingID = zoomUser.Pmi
 
@@ -799,9 +801,9 @@ func (p *Plugin) sendUserSettingForm(userID, channelID, rootID string) error {
 	}
 
 	switch userPMISettingPref {
-	case zoomPMISettingValueAsk:
+	case "", zoomPMISettingValueAsk:
 		currentValue = ask
-	case "", trueString:
+	case trueString:
 		currentValue = yes
 	default:
 		currentValue = no
@@ -823,7 +825,7 @@ func (p *Plugin) slackAttachmentToUpdatePMI(currentValue, channelID string) *mod
 	apiEndPoint := fmt.Sprintf("/plugins/%s%s", manifest.ID, pathUpdatePMI)
 
 	slackAttachment := model.SlackAttachment{
-		Fallback: "You can not set your preference",
+		Fallback: "Failed to set your preference",
 		Title:    "*Setting: Use your Personal Meeting ID*",
 		Text:     fmt.Sprintf("\n\nDo you want to use your Personal Meeting ID when starting a meeting?\n\nCurrent value: %s", currentValue),
 		Actions: []*model.PostAction{


### PR DESCRIPTION
#### Summary
- Updated the default setting for meeting ID
- Updated the message on "ask meeting type" slack attachment.

#### Screenshot:
![image](https://github.com/mattermost/mattermost-plugin-zoom/assets/55234496/eb138b83-011a-42f9-8691-4718556838ae)

#### What to test:
- When a user creates a Zoom meeting, he should get an attachment to select the meeting type for that meeting.
Note: Make sure that the user has not set their meeting preference with the `/zoom settings` command.

#### Ticket Link
Fixes https://community.mattermost.com/core/pl/nc17jfy4zi85jcq7dw57j1trwy

