### PR TITLE
[MM-329] Fix issue of not able to access post button while navigating using tab

### DIFF
--- a/webapp/src/components/post_type_zoom/post_type_zoom.jsx
+++ b/webapp/src/components/post_type_zoom/post_type_zoom.jsx
@@ -173,14 +173,14 @@ export default class PostTypeZoom extends React.PureComponent {
             subtitle = 'What do you want to do?';
             content = (
                 <div>
-                    <a
+                    <button
                         className='btn btn-lg btn-primary'
                         style={style.button}
                         rel='noopener noreferrer'
                         onClick={() => this.props.actions.startMeeting(post.channel_id, post.root_id, true, props.meeting_topic)}
                     >
                         {'CREATE NEW MEETING'}
-                    </a>
+                    </button>
                     <a
                         className='btn btn-lg btn-primary'
                         style={style.button}


### PR DESCRIPTION
#### Summary

- Fixed the issue of user not able to navigate post button when given option to `Create New Meeting` or `Join Existing Meeting`

#### Ticket Link
#68 