### PR TITLE
Fix issue of settings command working for non-connected users

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -261,6 +261,14 @@ func (p *Plugin) runHelpCommand(user *model.User) (string, error) {
 }
 
 func (p *Plugin) runSettingCommand(args *model.CommandArgs, params []string, user *model.User) (string, error) {
+	if _, authErr := p.authenticateAndFetchZoomUser(user); authErr != nil {
+		// the user state will be needed later while connecting the user to Zoom via OAuth
+		if appErr := p.storeOAuthUserState(user.Id, args.ChannelId, false); appErr != nil {
+			p.API.LogWarn("failed to store user state")
+		}
+		return authErr.Message, authErr.Err
+	}
+
 	if len(params) == 0 {
 		if err := p.sendUserSettingForm(user.Id, args.ChannelId, args.RootId); err != nil {
 			return "", err


### PR DESCRIPTION
#### Summary
- Fixed issue of settings command working for non-connected users

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-zoom/issues/346

#### What to test?
- Test the `/zoom settings` command should not work for non-connected users.

#### Checklist
- [x] Completed dev testing
- [x] `make test` Ran test cases and ensured they are passing
- [x] `make check-style` Ran style check and ensured both webapp and server pass the checks
