### PR TITLE
[MM-570] Use KV store to store user preference

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -270,17 +270,6 @@ func (p *Plugin) runSettingCommand(args *model.CommandArgs, params []string, use
 	return fmt.Sprintf("Unknown Action %v", ""), nil
 }
 
-func (p *Plugin) updateUserPersonalSettings(usePMIValue, userID string) *model.AppError {
-	return p.API.UpdatePreferencesForUser(userID, []model.Preference{
-		{
-			UserId:   userID,
-			Category: zoomPreferenceCategory,
-			Name:     zoomPMISettingName,
-			Value:    usePMIValue,
-		},
-	})
-}
-
 // getAutocompleteData retrieves auto-complete data for the "/zoom" command
 func (p *Plugin) getAutocompleteData() *model.AutocompleteData {
 	canConnect := !p.configuration.AccountLevelApp

--- a/server/http.go
+++ b/server/http.go
@@ -116,7 +116,7 @@ func (p *Plugin) submitFormPMIForMeeting(w http.ResponseWriter, r *http.Request)
 			meetingIDType = "unique"
 		}
 
-		if err := p.updateUserPersonalSettings(val, userID); err != nil {
+		if err := p.storeUserPreference(userID, val); err != nil {
 			p.API.LogWarn("failed to update preferences for the user", "Error", err.Error())
 			return
 		}
@@ -227,7 +227,7 @@ func (p *Plugin) submitFormPMIForPreference(w http.ResponseWriter, r *http.Reque
 		val = trueString
 	}
 
-	if err = p.updateUserPersonalSettings(val, mattermostUserID); err != nil {
+	if err := p.storeUserPreference(mattermostUserID, val); err != nil {
 		p.API.LogWarn("failed to update preferences for the user", "Error", err.Error())
 		return
 	}
@@ -508,17 +508,12 @@ func (p *Plugin) askPreferenceForMeeting(userID, channelID, rootID string) {
 }
 
 func (p *Plugin) getPMISettingData(userID string) (string, error) {
-	preferences, reqErr := p.API.GetPreferencesForUser(userID)
+	preference, reqErr := p.getUserPreference(userID)
 	if reqErr != nil {
 		return "", errors.New(settingDataError)
 	}
 
-	for _, preference := range preferences {
-		if preference.UserId == userID && preference.Category == zoomPreferenceCategory && preference.Name == zoomPMISettingName {
-			return preference.Value, nil
-		}
-	}
-	return "", nil
+	return preference, nil
 }
 
 func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -171,15 +171,6 @@ func TestPlugin(t *testing.T) {
 					SiteURL: &siteURL,
 				},
 			})
-			api.On("GetPreferencesForUser", mock.AnythingOfType("string")).Return([]model.Preference{
-				{
-					UserId:   "test-userid",
-					Category: zoomPreferenceCategory,
-					Name:     zoomPMISettingName,
-					Value:    trueString,
-				},
-			}, nil)
-
 			p := Plugin{}
 			p.setConfiguration(&configuration{
 				ZoomAPIURL:        ts.URL,

--- a/server/store.go
+++ b/server/store.go
@@ -213,7 +213,7 @@ func (p *Plugin) storeUserPreference(userID, value string) error {
 		return err
 	}
 
-	if err := p.API.KVSet(fmt.Sprintf(zoomUserPreferenceKey, userID), encoded); err != nil {
+	if _, err := p.client.KV.Set(fmt.Sprintf(zoomUserPreferenceKey, userID), encoded); err != nil {
 		return err
 	}
 
@@ -221,8 +221,8 @@ func (p *Plugin) storeUserPreference(userID, value string) error {
 }
 
 func (p *Plugin) getUserPreference(userID string) (string, error) {
-	encoded, err := p.API.KVGet(fmt.Sprintf(zoomUserPreferenceKey, userID))
-	if err != nil {
+	var encoded []byte
+	if err := p.client.KV.Get(fmt.Sprintf(zoomUserPreferenceKey, userID), &encoded); err != nil {
 		return "", err
 	}
 
@@ -241,7 +241,7 @@ func (p *Plugin) getUserPreference(userID string) (string, error) {
 					If found return the value, and remove user preference from preferences table and store in kv store
 				*/
 				if err := p.storeUserPreference(userID, preference.Value); err != nil {
-					p.API.LogError("Unable to store user prefernce", "UserID", userID, "Error", err.Error())
+					p.client.Log.Error("Unable to store user prefernce", "UserID", userID, "Error", err.Error())
 					return preference.Value, nil
 				}
 
@@ -252,7 +252,7 @@ func (p *Plugin) getUserPreference(userID string) (string, error) {
 					Name:     zoomPMISettingName,
 					Value:    preference.Value,
 				}}); err != nil {
-					p.API.LogError("Unable to delete user prefernce from db", "UserID", userID, "Error", err.Error())
+					p.client.Log.Error("Unable to delete user prefernce from db", "UserID", userID, "Error", err.Error())
 				}
 
 				return preference.Value, nil

--- a/server/store.go
+++ b/server/store.go
@@ -208,7 +208,7 @@ func (p *Plugin) removeSuperUserToken() error {
 }
 
 func (p *Plugin) storeUserPreference(userID, value string) error {
-	if _, err := p.client.KV.Set(fmt.Sprintf(zoomUserPreferenceKey, userID), value); err != nil {
+	if _, err := p.client.KV.Set(fmt.Sprintf(zoomUserPreferenceKey, userID), &value); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### Summary
- Added logic to use KV store for storing user preferences instead of the preference table
- Added logic to delete preference from preference table after storing it in the kv store for existing users

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-zoom/issues/340

#### How to test?
- Install any existing Zoom release and configure the plugin and select any preference for a user.
- Configure the plugin with this PR's build and check if the setting remains the same and the user is able to create the meeting with the selected preference.
