### PR TITLE
[GH-373]: Fixed the issue of zoom plugin sending confirmation although meeting started in last 30 seconds have ended

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -743,6 +743,11 @@ func (p *Plugin) checkPreviousMessages(channelID string) (recentMeeting bool, me
 			continue
 		}
 
+		meetingStatus := getString("meeting_status", post.Props)
+		if meetingStatus == zoom.WebhookStatusEnded {
+			continue
+		}
+
 		creator := getString("meeting_creator_username", post.Props)
 
 		return true, meetingLink, creator, meetingProvider, nil


### PR DESCRIPTION
#### Summary
The Zoom plugin had an issue where if a meeting link was posted in a channel within the last 30 seconds, the Zoom plugin would send a reminder post that a meeting link had been posted in the channel, regardless of whether the meeting had ended or not. This PR fixes the issue of reminder posts being sent even though the meeting has ended.
**Requisite**: The webhook needs to be set up and working properly.

#### Issues
  Fixes #373 

#### What to test
-Set up the Zoom plugin and the webhook.
- Start a meeting and end it instantly.
- Create a new meeting within 30 seconds.

##### Existing
- The Zoom plugin posts a reminder that a meeting link has already been posted in the channel in the last 30 seconds.

##### Fixed
- A new meeting link is posted if all meetings from the last 30 seconds have ended.