### PR TITLE
[MM-546]: Upgraded the min_server_version to 8.1.0 from 5.37.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-zoom",
     "support_url": "https://github.com/mattermost/mattermost-plugin-zoom/issues",
     "icon_path": "assets/profile.svg",
-    "min_server_version": "5.37.0",
+    "min_server_version": "8.1.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
#### Summary
Upgraded the `min_server_version` for zoom plugin to 8.1.0 from 5.37.0

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-zoom/issues/392
