### PR TITLE
[MM-68481] Scope meeting_started websocket broadcast to originating connection

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -215,7 +215,7 @@ func (p *Plugin) runStartCommand(args *model.CommandArgs, user *model.User, topi
 		}
 	}
 
-	if postMeetingErr := p.postMeeting(user, meetingID, meetingUUID, args.ChannelId, args.RootId, topic); postMeetingErr != nil {
+	if postMeetingErr := p.postMeeting(user, meetingID, meetingUUID, args.ChannelId, args.RootId, topic, ""); postMeetingErr != nil {
 		return "", postMeetingErr
 	}
 

--- a/server/http.go
+++ b/server/http.go
@@ -61,10 +61,11 @@ var ZoomChannelPreferences = map[string]string{
 }
 
 type startMeetingRequest struct {
-	ChannelID string `json:"channel_id"`
-	RootID    string `json:"root_id"`
-	Topic     string `json:"topic"`
-	UsePMI    string `json:"use_pmi"`
+	ChannelID    string `json:"channel_id"`
+	RootID       string `json:"root_id"`
+	Topic        string `json:"topic"`
+	UsePMI       string `json:"use_pmi"`
+	ConnectionID string `json:"connection_id"`
 }
 
 type ErrorResponse struct {
@@ -246,7 +247,7 @@ func (p *Plugin) startMeeting(action, userID, channelID, rootID string) {
 		}
 	}
 
-	if postMeetingErr := p.postMeeting(user, meetingID, meetingUUID, channelID, rootID, defaultMeetingTopic); postMeetingErr != nil {
+	if postMeetingErr := p.postMeeting(user, meetingID, meetingUUID, channelID, rootID, defaultMeetingTopic, ""); postMeetingErr != nil {
 		p.API.LogWarn("failed to post the meeting", "Error", postMeetingErr.Error())
 		return
 	}
@@ -435,7 +436,7 @@ func (p *Plugin) completeUserOAuthToZoom(w http.ResponseWriter, r *http.Request)
 		p.postEphemeral(userID, channelID, "", "Successfully connected to Zoom")
 	} else {
 		// Returning error might not be appropriate here as the main logic for this API is to connect users.
-		if _, err := p.handleMeetingCreation(channelID, "", defaultMeetingTopic, user, zoomUser); err != nil {
+		if _, err := p.handleMeetingCreation(channelID, "", defaultMeetingTopic, "", user, zoomUser); err != nil {
 			p.API.LogWarn("Error in creating meeting", "Error", err.Error())
 		}
 	}
@@ -460,7 +461,7 @@ func (p *Plugin) completeUserOAuthToZoom(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-func (p *Plugin) postMeeting(creator *model.User, meetingID int, meetingUUID string, channelID string, rootID string, topic string) error {
+func (p *Plugin) postMeeting(creator *model.User, meetingID int, meetingUUID string, channelID string, rootID string, topic string, connectionID string) error {
 	meetingURL := p.getMeetingURL(creator, meetingID)
 
 	if topic == "" {
@@ -511,12 +512,17 @@ func (p *Plugin) postMeeting(creator *model.User, meetingID int, meetingUUID str
 		p.API.LogWarn("failed to store channel for meeting", "error", err.Error())
 	}
 
+	broadcast := &model.WebsocketBroadcast{UserId: creator.Id}
+	if connectionID != "" {
+		broadcast.ConnectionId = connectionID
+	}
+
 	p.client.Frontend.PublishWebSocketEvent(
 		WebsocketEventMeetingStarted,
 		map[string]interface{}{
 			"meeting_url": meetingURL,
 		},
-		&model.WebsocketBroadcast{UserId: creator.Id},
+		broadcast,
 	)
 
 	return nil
@@ -665,7 +671,7 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 		topic = defaultMeetingTopic
 	}
 
-	meetingURL, err := p.handleMeetingCreation(req.ChannelID, req.RootID, topic, user, zoomUser)
+	meetingURL, err := p.handleMeetingCreation(req.ChannelID, req.RootID, topic, req.ConnectionID, user, zoomUser)
 	if err != nil {
 		p.API.LogWarn("Error in creating meeting", "Error", err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -1093,7 +1099,7 @@ func (mv ZoomChannelSettingsMapValue) IsValid() error {
 	return nil
 }
 
-func (p *Plugin) handleMeetingCreation(channelID, rootID, topic string, user *model.User, zoomUser *zoom.User) (string, error) {
+func (p *Plugin) handleMeetingCreation(channelID, rootID, topic, connectionID string, user *model.User, zoomUser *zoom.User) (string, error) {
 	var meetingID int
 	var meetingUUID string
 	var createMeetingErr error
@@ -1125,7 +1131,7 @@ func (p *Plugin) handleMeetingCreation(channelID, rootID, topic string, user *mo
 		}
 	}
 
-	if postMeetingErr := p.postMeeting(user, meetingID, meetingUUID, channelID, rootID, topic); postMeetingErr != nil {
+	if postMeetingErr := p.postMeeting(user, meetingID, meetingUUID, channelID, rootID, topic, connectionID); postMeetingErr != nil {
 		return "", postMeetingErr
 	}
 

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -137,7 +137,7 @@ func TestPlugin(t *testing.T) {
 			api.On("GetUser", botUserID).Return(&model.User{
 				Id: botUserID,
 			}, nil)
-			api.On("PublishWebSocketEvent", "meeting_started", map[string]interface{}{"meeting_url": "https://zoom.us/j/234"}, &model.WebsocketBroadcast{UserId: botUserID}).Return()
+			api.On("PublishWebSocketEvent", "meeting_started", map[string]interface{}{"meeting_url": "https://zoom.us/j/234"}, mock.AnythingOfType("*model.WebsocketBroadcast")).Return()
 
 			api.On("SendEphemeralPost", "theuserid", mock.AnythingOfType("*model.Post")).Return(nil)
 

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -156,7 +156,7 @@ func (p *Plugin) handleMeetingStarted(w http.ResponseWriter, _ *http.Request, bo
 		return
 	}
 
-	if postMeetingErr := p.postMeeting(botUser, meetingID, webhook.Payload.Object.UUID, channelID, "", webhook.Payload.Object.Topic); postMeetingErr != nil {
+	if postMeetingErr := p.postMeeting(botUser, meetingID, webhook.Payload.Object.UUID, channelID, "", webhook.Payload.Object.Topic, ""); postMeetingErr != nil {
 		p.API.LogError("Failed to post the zoom message in the channel", "err", postMeetingErr.Error())
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -8,8 +8,9 @@ import Client from '../client';
 export function startMeeting(channelId, rootId = '', force = false, topic = '') {
     return async (dispatch, getState) => {
         const userId = getState().entities.bots.accounts.user_id;
+        const connectionId = getState().websocket?.connectionId || '';
         try {
-            const {error} = await Client.startMeeting(channelId, rootId, topic, force);
+            const {error} = await Client.startMeeting(channelId, rootId, topic, force, connectionId);
             if (error) {
                 dispatchError(dispatch, channelId, rootId, userId, error);
                 return error;

--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -11,11 +11,12 @@ export default class Client {
         this.url = url + '/plugins/' + manifest.id;
     }
 
-    startMeeting = async (channelId, rootId, topic = '', force = false) => {
+    startMeeting = async (channelId, rootId, topic = '', force = false, connectionId = '') => {
         const res = await doPost(`${this.url}/api/v1/meetings${force ? '?force=true' : ''}`, {
             channel_id: channelId,
             topic,
             root_id: rootId,
+            connection_id: connectionId,
         });
 
         return {meetingUrl: res.meeting_url, error: res.error};


### PR DESCRIPTION
#### Summary
Passes the webapp's websocket connection_id in the POST /api/v1/meetings request body and sets WebsocketBroadcast.ConnectionId on the meeting_started event to scope to the originating session only. Flows without a connection ID fall back to the existing user scoped broadcast.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68481


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** Changes span multiple layers and modify method signatures across the codebase, but the additions are backward-compatible with sensible defaults (empty string fallback to existing behavior). The modification touches websocket broadcast scoping, which is a critical path, but the change is well-isolated to the meeting_started event flow.

**Regression Risk:** Low-to-Medium. The parameter additions include defaults, so existing callers without connection_id continue to work. However, any untested code paths in websocket event delivery or session handling adjacent to the modified broadcast logic could be affected. The change correctly passes an empty string where connection_id is unavailable (commands, webhooks), preserving the original broadcast scope.

**QA Recommendation:** Medium manual QA effort recommended. Focus testing on: (1) multi-tab scenarios where multiple browser sessions start meetings to verify broadcast scoping works correctly; (2) fallback behavior when connection_id is unavailable or empty (command-line triggered meetings); (3) single-session happy path to ensure no regression in typical flow. Automated testing of websocket event scoping is recommended if not already in place. Risk of skipping manual QA is moderate—scoping issues in broadcast could cause meeting notifications to leak across sessions unexpectedly.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->