### PR TITLE
[MM-69855] Guard HTTP handlers against nil-decoded request bodies

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -76,43 +76,64 @@ type MeetingURLResponse struct {
 	MeetingURL string `json:"meeting_url"`
 }
 
+// responseWriterRecorder tracks whether a response has been written so panic
+// recovery can avoid writing to an already-committed response.
+type responseWriterRecorder struct {
+	http.ResponseWriter
+	wroteHeader bool
+}
+
+func (rw *responseWriterRecorder) WriteHeader(code int) {
+	rw.wroteHeader = true
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *responseWriterRecorder) Write(b []byte) (int, error) {
+	rw.wroteHeader = true
+	return rw.ResponseWriter.Write(b)
+}
+
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
+	rw := &responseWriterRecorder{ResponseWriter: w}
+
 	// Recover from any unexpected panic so a single bad request cannot terminate
 	// the plugin subprocess and take down all Zoom routes.
 	defer func() {
 		if rec := recover(); rec != nil {
 			p.API.LogError("Recovered from panic while serving HTTP request", "path", r.URL.Path, "error", fmt.Sprintf("%v", rec))
-			http.Error(w, "internal server error", http.StatusInternalServerError)
+			if !rw.wroteHeader {
+				http.Error(rw, "internal server error", http.StatusInternalServerError)
+			}
 		}
 	}()
 
 	config := p.getConfiguration()
 	if err := config.IsValid(p.isCloudLicense()); err != nil {
-		http.Error(w, "This plugin is not configured.", http.StatusNotImplemented)
+		http.Error(rw, "This plugin is not configured.", http.StatusNotImplemented)
 		return
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+	r.Body = http.MaxBytesReader(rw, r.Body, maxRequestBodySize)
 
 	switch path := r.URL.Path; path {
 	case pathWebhook:
-		p.handleWebhook(w, r)
+		p.handleWebhook(rw, r)
 	case pathStartMeeting:
-		p.handleStartMeeting(w, r)
+		p.handleStartMeeting(rw, r)
 	case pathConnectUser:
-		p.connectUserToZoom(w, r)
+		p.connectUserToZoom(rw, r)
 	case pathCompleteUserOAuth:
-		p.completeUserOAuthToZoom(w, r)
+		p.completeUserOAuthToZoom(rw, r)
 	case pathDeauthorizeUser:
-		p.deauthorizeUser(w, r)
+		p.deauthorizeUser(rw, r)
 	case pathUpdatePMI:
-		p.submitFormPMIForPreference(w, r)
+		p.submitFormPMIForPreference(rw, r)
 	case pathAskPMI:
-		p.submitFormPMIForMeeting(w, r)
+		p.submitFormPMIForMeeting(rw, r)
 	case pathChannelPreference:
-		p.handleChannelPreference(w, r)
+		p.handleChannelPreference(rw, r)
 	default:
-		http.NotFound(w, r)
+		http.NotFound(rw, r)
 	}
 }
 

--- a/server/http.go
+++ b/server/http.go
@@ -77,6 +77,15 @@ type MeetingURLResponse struct {
 }
 
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
+	// Recover from any unexpected panic so a single bad request cannot terminate
+	// the plugin subprocess and take down all Zoom routes.
+	defer func() {
+		if rec := recover(); rec != nil {
+			p.API.LogError("Recovered from panic while serving HTTP request", "path", r.URL.Path, "error", fmt.Sprintf("%v", rec))
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}
+	}()
+
 	config := p.getConfiguration()
 	if err := config.IsValid(p.isCloudLicense()); err != nil {
 		http.Error(w, "This plugin is not configured.", http.StatusNotImplemented)
@@ -117,6 +126,11 @@ func (p *Plugin) submitFormPMIForMeeting(w http.ResponseWriter, r *http.Request)
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			http.Error(w, "failed to write the response", http.StatusInternalServerError)
 		}
+		return
+	}
+	if postActionIntegrationRequest == nil {
+		p.API.LogWarn("Empty PostActionIntegrationRequest body")
+		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
 
@@ -261,6 +275,11 @@ func (p *Plugin) submitFormPMIForPreference(w http.ResponseWriter, r *http.Reque
 		if err := json.NewEncoder(w).Encode(response); err != nil {
 			http.Error(w, "failed to write the response", http.StatusInternalServerError)
 		}
+		return
+	}
+	if postActionIntegrationRequest == nil {
+		p.API.LogWarn("Empty PostActionIntegrationRequest body")
+		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
 
@@ -683,6 +702,11 @@ func (p *Plugin) handleChannelPreference(w http.ResponseWriter, r *http.Request)
 	if err := decoder.Decode(&submitRequest); err != nil {
 		p.API.LogError("Error decoding dialog request", "Error", err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if submitRequest == nil {
+		p.API.LogError("Empty dialog request body")
+		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
 

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -155,6 +155,44 @@ func TestSubmitFormPMIForPreference(t *testing.T) {
 	}
 }
 
+// A JSON `null` body decodes without error but leaves the target pointer nil.
+// These tests ensure the handlers return 400 instead of panicking and crashing
+// the plugin process (MM-69855).
+func TestHandlersRejectNullBody(t *testing.T) {
+	for name, handler := range map[string]func(p *Plugin, w http.ResponseWriter, r *http.Request){
+		"submitFormPMIForMeeting": func(p *Plugin, w http.ResponseWriter, r *http.Request) {
+			p.submitFormPMIForMeeting(w, r)
+		},
+		"submitFormPMIForPreference": func(p *Plugin, w http.ResponseWriter, r *http.Request) {
+			p.submitFormPMIForPreference(w, r)
+		},
+		"handleChannelPreference": func(p *Plugin, w http.ResponseWriter, r *http.Request) {
+			p.handleChannelPreference(w, r)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			api := &plugintest.API{}
+			p := Plugin{}
+			p.SetAPI(api)
+
+			api.On("LogWarn", mock.Anything).Maybe().Return()
+			api.On("LogWarn", mock.Anything, mock.Anything, mock.Anything).Maybe().Return()
+			api.On("LogError", mock.Anything).Maybe().Return()
+			api.On("LogError", mock.Anything, mock.Anything, mock.Anything).Maybe().Return()
+
+			request := httptest.NewRequest(http.MethodPost, "/null-body", bytes.NewReader([]byte("null")))
+			request.Header.Set(MattermostUserIDHeader, "user1")
+
+			rr := httptest.NewRecorder()
+
+			require.NotPanics(t, func() {
+				handler(&p, rr, request)
+			})
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+		})
+	}
+}
+
 func TestHandleChannelPreferenceAuth(t *testing.T) {
 	for name, tc := range map[string]struct {
 		headerUserID         string

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest/mock"
 )
@@ -153,6 +154,74 @@ func TestSubmitFormPMIForPreference(t *testing.T) {
 			assert.Equal(t, tc.expectStatus, rr.Code)
 		})
 	}
+}
+
+// panicAfterWriteWriter commits the response body, then panics so ServeHTTP's
+// recover path can be exercised after headers are already written.
+type panicAfterWriteWriter struct {
+	http.ResponseWriter
+	message string
+}
+
+func (w *panicAfterWriteWriter) Write(b []byte) (int, error) {
+	n, err := w.ResponseWriter.Write(b)
+	if err != nil {
+		return n, err
+	}
+	panic(w.message)
+}
+
+func TestServeHTTPRecoversFromPanic(t *testing.T) {
+	validConfig := &configuration{
+		WebhookSecret:     "secret",
+		EncryptionKey:     "4Su-mLR7N6VwC6aXjYhQoT0shtS9fKz+",
+		OAuthClientID:     "clientid",
+		OAuthClientSecret: "clientsecret",
+	}
+
+	t.Run("panic before response is committed returns 500", func(t *testing.T) {
+		api := &plugintest.API{}
+		p := Plugin{}
+		p.SetAPI(api)
+		p.setConfiguration(validConfig)
+
+		api.On("GetLicense").Return(nil).Run(func(args mock.Arguments) {
+			panic("boom before write")
+		})
+		api.On("LogError", "Recovered from panic while serving HTTP request", "path", "/", "error", "boom before write").Once()
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		require.NotPanics(t, func() {
+			p.ServeHTTP(&plugin.Context{}, rr, req)
+		})
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+		assert.Contains(t, rr.Body.String(), "internal server error")
+		api.AssertExpectations(t)
+	})
+
+	t.Run("panic after response is committed leaves status untouched", func(t *testing.T) {
+		api := &plugintest.API{}
+		p := Plugin{}
+		p.SetAPI(api)
+		p.setConfiguration(validConfig)
+
+		api.On("GetLicense").Return(nil)
+		api.On("LogError", "Recovered from panic while serving HTTP request", "path", "/unknown", "error", "boom after write").Once()
+
+		rr := httptest.NewRecorder()
+		w := &panicAfterWriteWriter{ResponseWriter: rr, message: "boom after write"}
+		req := httptest.NewRequest(http.MethodGet, "/unknown", nil)
+
+		require.NotPanics(t, func() {
+			p.ServeHTTP(&plugin.Context{}, w, req)
+		})
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+		assert.Contains(t, rr.Body.String(), "404 page not found")
+		assert.NotContains(t, rr.Body.String(), "internal server error")
+		api.AssertExpectations(t)
+	})
 }
 
 // A JSON `null` body decodes without error but leaves the target pointer nil.


### PR DESCRIPTION
## Summary

The plugin's HTTP handlers decoded request bodies into struct pointers and used the result without checking for `nil`. This change hardens the request handling in `server/http.go`:

- Add a `nil` check after decoding the body in `submitFormPMIForMeeting`, `submitFormPMIForPreference`, and `handleChannelPreference`, returning `400 Bad Request` instead of dereferencing the decoded value.
- Wrap the `ServeHTTP` dispatcher in a `defer`/`recover` so an unexpected panic returns `500` rather than terminating the plugin subprocess. A response-writer wrapper ensures the `500` is only written when no response has been committed yet.

## Ticket Link

https://mattermost.atlassian.net/browse/MM-69855

## Tests

- Added `TestHandlersRejectNullBody`, exercising all three handlers. Verified the tests fail (panic) when the fix is reverted and pass with the fix in place.
- `cd server && go test ./...` and `make check-style` pass.

## Release Note

```release-note
Fixed an issue where the Zoom plugin could stop responding when it received a malformed request body.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The update hardens shared HTTP request dispatch and error-handling behavior in `server/http.go`, changing how malformed JSON (`null`) and panics are surfaced to clients. Regression tests cover both null-body handling and panic recovery before/after response commitment, reducing—but not eliminating—risk.

**Regression Risk:** Moderate; behavior changes affect response generation and recovery paths that run for multiple handlers, but the modifications are localized to HTTP plumbing (not auth/session or persistence).

**QA Recommendation:** Perform limited manual QA focused on malformed JSON inputs and induced handler panics (pre- and post-write); otherwise rely on the added automated regression tests. Skipping manual QA is moderately risky.

*Generated by CodeRabbitAI*

### Release notes

Fixed an issue where the Zoom plugin could stop responding after receiving a malformed request body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->