### PR TITLE
[MM-69470] Reject Zoom webhooks when the Zoom webhook secret is unset

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -88,7 +88,7 @@
                 "key": "ZoomWebhookSecret",
                 "display_name": "Zoom Webhook Secret:",
                 "type": "text",
-                "help_text": "Secret Token taken from Zoom's webhook configuration page",
+                "help_text": "Secret Token taken from Zoom's webhook configuration page. Required: webhook events are rejected while this is empty.",
                 "regenerate_help_text": "",
                 "placeholder": "",
                 "default": null,

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -10,8 +10,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,6 +26,19 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-zoom/server/zoom"
 )
+
+const testZoomWebhookSecret = "thezoomwebhooksecret"
+
+func signZoomWebhookRequest(t *testing.T, r *http.Request, body string) {
+	t.Helper()
+
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	hash, err := createWebhookSignatureHash(testZoomWebhookSecret, fmt.Sprintf("v0:%s:%s", ts, body))
+	require.NoError(t, err)
+
+	r.Header.Set("x-zm-request-timestamp", ts)
+	r.Header.Set("x-zm-signature", "v0="+hash)
+}
 
 func TestPlugin(t *testing.T) {
 	// Mock Zoom server
@@ -66,8 +81,11 @@ func TestPlugin(t *testing.T) {
 
 	endedPayload := `{"event": "meeting.ended", "payload": {"object": {"id": "234", "uuid": "234"}}}`
 	validStoppedWebhookRequest := httptest.NewRequest("POST", "/webhook?secret=thewebhooksecret", strings.NewReader(endedPayload))
+	signZoomWebhookRequest(t, validStoppedWebhookRequest, endedPayload)
 
-	validStartedWebhookRequest := httptest.NewRequest("POST", "/webhook?secret=thewebhooksecret", strings.NewReader(`{"event": "meeting.started", "payload": {"object": {"id": "234", "uuid": "234"}}}`))
+	startedPayload := `{"event": "meeting.started", "payload": {"object": {"id": "234", "uuid": "234"}}}`
+	validStartedWebhookRequest := httptest.NewRequest("POST", "/webhook?secret=thewebhooksecret", strings.NewReader(startedPayload))
+	signZoomWebhookRequest(t, validStartedWebhookRequest, startedPayload)
 
 	noSecretWebhookRequest := httptest.NewRequest("POST", "/webhook", strings.NewReader(endedPayload))
 
@@ -202,6 +220,7 @@ func TestPlugin(t *testing.T) {
 			p.setConfiguration(&configuration{
 				ZoomAPIURL:              ts.URL,
 				WebhookSecret:           "thewebhooksecret",
+				ZoomWebhookSecret:       testZoomWebhookSecret,
 				EncryptionKey:           "4Su-mLR7N6VwC6aXjYhQoT0shtS9fKz+",
 				OAuthClientID:           "clientid",
 				OAuthClientSecret:       "clientsecret",

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -552,7 +552,7 @@ const webhookTimestampMaxAge = 5 * time.Minute
 func (p *Plugin) verifyZoomWebhookSignature(r *http.Request, body []byte) error {
 	config := p.getConfiguration()
 	if config.ZoomWebhookSecret == "" {
-		return nil
+		return errors.New("zoom webhook secret not set")
 	}
 
 	var webhook zoom.Webhook

--- a/server/webhook_test.go
+++ b/server/webhook_test.go
@@ -333,17 +333,11 @@ func TestWebhookEmptyZoomWebhookSecret(t *testing.T) {
 	p.setConfiguration(configWithoutSecret)
 
 	api.On("GetLicense").Return(nil)
-	api.On("KVGet", "post_meeting_123").Return(nil, &model.AppError{StatusCode: 200})
-	api.On("KVGet", "meeting_channel_123").Return(nil, (*model.AppError)(nil))
 	allowFlexibleLogging(api)
 	p.SetAPI(api)
 	p.client = pluginapi.NewClient(p.API, p.Driver)
 
 	requestBody := `{"payload":{"object": {"id": "123", "uuid": "123"}},"event":"meeting.ended"}`
-
-	ts := "1660149894817"
-	h := hmac.New(sha256.New, []byte(testConfig.ZoomWebhookSecret))
-	_, _ = h.Write([]byte("v0:" + ts + ":" + requestBody))
 
 	w := httptest.NewRecorder()
 	reqBody := io.NopCloser(bytes.NewBufferString(requestBody))
@@ -352,7 +346,42 @@ func TestWebhookEmptyZoomWebhookSecret(t *testing.T) {
 
 	p.ServeHTTP(&plugin.Context{}, w, request)
 
-	require.Equal(t, http.StatusNotFound, w.Result().StatusCode)
+	require.Equal(t, http.StatusUnauthorized, w.Result().StatusCode)
+}
+
+func TestWebhookEmptyZoomWebhookSecretWithValidSignature(t *testing.T) {
+	api := &plugintest.API{}
+	p := Plugin{}
+
+	configWithoutSecret := &configuration{
+		OAuthClientID:     "clientid",
+		OAuthClientSecret: "clientsecret",
+		EncryptionKey:     "encryptionkey",
+		WebhookSecret:     "webhooksecret",
+		ZoomWebhookSecret: "",
+	}
+	p.setConfiguration(configWithoutSecret)
+
+	api.On("GetLicense").Return(nil)
+	allowFlexibleLogging(api)
+	p.SetAPI(api)
+	p.client = pluginapi.NewClient(p.API, p.Driver)
+
+	requestBody := `{"payload":{"object": {"id": "123", "uuid": "123"}},"event":"meeting.ended"}`
+
+	ts := fmt.Sprintf("%d", time.Now().Unix())
+	hash, _ := createWebhookSignatureHash("", fmt.Sprintf("v0:%s:%s", ts, requestBody))
+
+	w := httptest.NewRecorder()
+	reqBody := io.NopCloser(bytes.NewBufferString(requestBody))
+	request := httptest.NewRequest("POST", "/webhook?secret=webhooksecret", reqBody)
+	request.Header.Add("Content-Type", "application/json")
+	request.Header.Add("x-zm-signature", fmt.Sprintf("v0=%s", hash))
+	request.Header.Add("x-zm-request-timestamp", ts)
+
+	p.ServeHTTP(&plugin.Context{}, w, request)
+
+	require.Equal(t, http.StatusUnauthorized, w.Result().StatusCode)
 }
 
 func TestWebhookVerifySignatureInvalid(t *testing.T) {


### PR DESCRIPTION
#### Summary
`verifyZoomWebhookSignature` returned `nil` when `ZoomWebhookSecret` was empty, silently skipping HMAC-SHA256 verification. With the secret unset, the only remaining check on `/plugins/zoom/webhook` was the `secret` query parameter, so an unsigned request carrying the correct `WebhookSecret` was accepted and processed and a forged `meeting.ended` event could overwrite the bot's meeting post. 

This now fails closes as an unset `ZoomWebhookSecret` returns an error and the request is rejected with 401.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-69470

#### QA Test Steps

1. Configure the Zoom plugin with both **Webhook Secret** and **Zoom Webhook Secret** set, and validate the webhook URL from the Zoom App Marketplace. Validation succeeds.
2. Run `/zoom start` in a channel, join the meeting, then end it. The bot post updates to show the meeting has ended.
3. Clear **Zoom Webhook Secret** in the System Console and save. Repeat step 2. The bot post no longer updates, and the server log shows `Could not verify webhook signature: zoom webhook secret not set`. This is the intended fail-closed behaviour.
4. Restore **Zoom Webhook Secret**. Step 2 works again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Reasoning:** The change modifies webhook authentication behavior and rejects unsigned requests when `ZoomWebhookSecret` is unset. The scope is isolated, and tests cover the affected paths.

**Regression Risk:** Medium. Existing configurations must define `ZoomWebhookSecret`. Misconfigured integrations will receive HTTP 401 responses.

** QA Recommendation:** Perform focused manual QA with configured and missing secrets. Skipping manual QA has moderate risk because the change affects webhook authentication.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->